### PR TITLE
feat: Refactored login workflow and added lobby

### DIFF
--- a/frontend/galactic-sovereign-frontend/src/lib/actions/backToLobby.ts
+++ b/frontend/galactic-sovereign-frontend/src/lib/actions/backToLobby.ts
@@ -1,0 +1,7 @@
+import { type RequestEvent, redirect } from '@sveltejs/kit';
+import { resetGameCookies } from '$lib/cookies';
+
+export const backToLobby = async ({ cookies }: RequestEvent) => {
+	resetGameCookies(cookies);
+	redirect(303, '/lobby');
+};

--- a/frontend/galactic-sovereign-frontend/src/lib/components/GamePageWrapper.svelte
+++ b/frontend/galactic-sovereign-frontend/src/lib/components/GamePageWrapper.svelte
@@ -31,6 +31,9 @@
 		<StyledText text={universeName} textColor="text-white" />
 		<StyledText text={playerName} textColor="text-white" />
 		<StyledText text={planetName} textColor="text-white" />
+		<form method="POST" action="?/backToLobby">
+			<button class="hover:underline">Back to the lobby</button>
+		</form>
 		<form method="POST" action="?/logout">
 			<button class="hover:underline">Logout</button>
 		</form>

--- a/frontend/galactic-sovereign-frontend/src/lib/cookies.ts
+++ b/frontend/galactic-sovereign-frontend/src/lib/cookies.ts
@@ -42,7 +42,6 @@ export function resetGameCookies(cookies: Cookies) {
 	cookies.set(COOKIE_KEY_UNIVERSE_ID, '', DEFAULT_COOKIES_OPT);
 }
 
-// TODO: To be removed.
 export function setCookies(cookies: Cookies, apiKey: ApiKey, player: Player) {
 	setSessionCookies(cookies, apiKey);
 	setGameCookies(cookies, player);

--- a/frontend/galactic-sovereign-frontend/src/lib/cookies.ts
+++ b/frontend/galactic-sovereign-frontend/src/lib/cookies.ts
@@ -20,51 +20,85 @@ export {
 	COOKIE_KEY_UNIVERSE_ID
 };
 
-export function resetCookies(cookies: Cookies) {
-	cookies.set(COOKIE_KEY_API_USER, '', DEFAULT_COOKIES_OPT);
-	cookies.set(COOKIE_KEY_API_KEY, '', DEFAULT_COOKIES_OPT);
-	cookies.set(COOKIE_KEY_PLAYER_ID, '', DEFAULT_COOKIES_OPT);
-	cookies.set(COOKIE_KEY_PLAYER_NAME, '', DEFAULT_COOKIES_OPT);
-	cookies.set(COOKIE_KEY_UNIVERSE_ID, '', DEFAULT_COOKIES_OPT);
-}
-
-export function setCookies(cookies: Cookies, apiKey: ApiKey, player: Player) {
+export function setSessionCookies(cookies: Cookies, apiKey: ApiKey) {
 	cookies.set(COOKIE_KEY_API_USER, apiKey.user, DEFAULT_COOKIES_OPT);
 	cookies.set(COOKIE_KEY_API_KEY, apiKey.key, DEFAULT_COOKIES_OPT);
+}
+
+export function resetSessionCookies(cookies: Cookies) {
+	cookies.set(COOKIE_KEY_API_USER, '', DEFAULT_COOKIES_OPT);
+	cookies.set(COOKIE_KEY_API_KEY, '', DEFAULT_COOKIES_OPT);
+}
+
+export function setGameCookies(cookies: Cookies, player: Player) {
 	cookies.set(COOKIE_KEY_PLAYER_ID, player.id, DEFAULT_COOKIES_OPT);
 	cookies.set(COOKIE_KEY_PLAYER_NAME, player.name, DEFAULT_COOKIES_OPT);
 	cookies.set(COOKIE_KEY_UNIVERSE_ID, player.universe, DEFAULT_COOKIES_OPT);
 }
 
-export interface GameCookies {
-	readonly apiUser: string;
-	readonly apiKey: string;
-	readonly playerId: string;
-	readonly playerName: string;
-	readonly universeId: string;
+export function resetGameCookies(cookies: Cookies) {
+	cookies.set(COOKIE_KEY_PLAYER_ID, '', DEFAULT_COOKIES_OPT);
+	cookies.set(COOKIE_KEY_PLAYER_NAME, '', DEFAULT_COOKIES_OPT);
+	cookies.set(COOKIE_KEY_UNIVERSE_ID, '', DEFAULT_COOKIES_OPT);
+}
+
+// TODO: To be removed.
+export function setCookies(cookies: Cookies, apiKey: ApiKey, player: Player) {
+	setSessionCookies(cookies, apiKey);
+	setGameCookies(cookies, player);
+}
+
+export function resetCookies(cookies: Cookies) {
+	resetSessionCookies(cookies);
+	resetGameCookies(cookies);
 }
 
 function validOrEmptyString(maybeValue: string | undefined, valid: boolean): string {
 	return valid ? (maybeValue as string) : '';
 }
 
-export function loadCookies(cookies: Cookies): [boolean, GameCookies] {
+export interface SessionCookies {
+	readonly apiUser: string;
+	readonly apiKey: string;
+}
+
+export function loadSessionCookies(cookies: Cookies): [boolean, SessionCookies] {
 	const maybeApiUser = cookies.get(COOKIE_KEY_API_USER);
 	const maybeApiKey = cookies.get(COOKIE_KEY_API_KEY);
+
+	const validApiUser = maybeApiUser !== undefined;
+	const validApiKey = maybeApiKey !== undefined;
+	const valid = validApiUser || validApiKey;
+
+	const out: SessionCookies = {
+		apiUser: validOrEmptyString(maybeApiUser, validApiUser),
+		apiKey: validOrEmptyString(maybeApiKey, validApiKey)
+	};
+
+	return [valid, out];
+}
+
+export interface GameCookies {
+	readonly session: SessionCookies;
+	readonly playerId: string;
+	readonly playerName: string;
+	readonly universeId: string;
+}
+
+export function loadCookies(cookies: Cookies): [boolean, GameCookies] {
 	const maybePlayerId = cookies.get(COOKIE_KEY_PLAYER_ID);
 	const maybePlayerName = cookies.get(COOKIE_KEY_PLAYER_NAME);
 	const maybeUniverseId = cookies.get(COOKIE_KEY_UNIVERSE_ID);
 
-	const validApiUser = maybeApiUser !== undefined;
-	const validApiKey = maybeApiKey !== undefined;
+	const [validSession, session] = loadSessionCookies(cookies);
+
 	const validPlayerId = maybePlayerId !== undefined;
 	const validPlayerName = maybePlayerName !== undefined;
 	const validUniverseId = maybeUniverseId !== undefined;
-	const valid = validApiUser || validApiKey || validPlayerId || validUniverseId;
+	const valid = validSession || validPlayerId || validUniverseId;
 
 	const out: GameCookies = {
-		apiUser: validOrEmptyString(maybeApiUser, validApiUser),
-		apiKey: validOrEmptyString(maybeApiKey, validApiKey),
+		session: session,
 		playerId: validOrEmptyString(maybePlayerId, validPlayerId),
 		playerName: validOrEmptyString(maybePlayerName, validPlayerName),
 		universeId: validOrEmptyString(maybeUniverseId, validUniverseId)

--- a/frontend/galactic-sovereign-frontend/src/lib/game/players.ts
+++ b/frontend/galactic-sovereign-frontend/src/lib/game/players.ts
@@ -1,7 +1,5 @@
 import { ResponseEnvelope } from '$lib/responseEnvelope';
 import { buildUrl, safeFetch } from '$lib/api';
-import { ApiKey, loginUser, logoutUser } from '$lib/sessions';
-import { User, createUser } from '$lib/users';
 
 export class Player {
 	readonly id: string = '00000000-0000-0000-0000-000000000000';
@@ -55,39 +53,6 @@ export async function createPlayer(
 	const jsonContent = await response.json();
 
 	return new ResponseEnvelope(jsonContent);
-}
-
-export async function registerPlayer(
-	email: string,
-	password: string,
-	universeId: string,
-	playerName: string
-): Promise<ResponseEnvelope> {
-	const signupResponse = await createUser(email, password);
-	if (signupResponse.error()) {
-		return signupResponse;
-	}
-
-	const apiUser = new User(signupResponse);
-
-	const loginResponse = await loginUser(email, password);
-	if (loginResponse.error()) {
-		return loginResponse;
-	}
-
-	const apiKey = new ApiKey(loginResponse);
-
-	const playerResponse = await createPlayer(apiUser.id, universeId, playerName, apiKey.key);
-	if (playerResponse.error()) {
-		return playerResponse;
-	}
-
-	const logoutResponse = await logoutUser(apiKey.key, apiKey.user);
-	if (logoutResponse.error()) {
-		return logoutResponse;
-	}
-
-	return playerResponse;
 }
 
 export async function fetchPlayerFromApiUser(

--- a/frontend/galactic-sovereign-frontend/src/routes/lobby/+page.server.ts
+++ b/frontend/galactic-sovereign-frontend/src/routes/lobby/+page.server.ts
@@ -1,0 +1,5 @@
+import { logout } from '$lib/actions/logout';
+
+export const actions = {
+	logout: logout
+};

--- a/frontend/galactic-sovereign-frontend/src/routes/lobby/+page.svelte
+++ b/frontend/galactic-sovereign-frontend/src/routes/lobby/+page.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { FlexContainer, StyledLink, StyledTitle } from '$lib/components';
+
+	import heroImage, { HOMEPAGE_HERO_IMAGE } from '$lib/stores/ui/heroImage';
+	import heroContainer, { HOMEPAGE_HERO_CONTAINER_PROPS } from '$lib/stores/ui/heroContainer';
+
+	heroImage.set(HOMEPAGE_HERO_IMAGE);
+	heroContainer.set(HOMEPAGE_HERO_CONTAINER_PROPS);
+</script>
+
+<FlexContainer>
+	<div class="fixed right-4 top-4">
+		<form method="POST" action="?/logout">
+			<button class="hover:underline text-white">Logout</button>
+		</form>
+	</div>
+
+	<FlexContainer extensible={false} styling="h-1/5">
+		<StyledTitle text="Galactic Sovereign" />
+	</FlexContainer>
+
+	<FlexContainer extensible={false} styling="h-3/5">
+		<StyledLink text="Join new universe" link="/lobby/register" showAsButton={true} />
+
+		<StyledLink text="Resume existing session" link="/lobby/login" showAsButton={true} />
+	</FlexContainer>
+</FlexContainer>

--- a/frontend/galactic-sovereign-frontend/src/routes/lobby/login/+page.server.ts
+++ b/frontend/galactic-sovereign-frontend/src/routes/lobby/login/+page.server.ts
@@ -1,0 +1,100 @@
+import { error, redirect } from '@sveltejs/kit';
+import { resetGameCookies, setGameCookies, loadSessionCookies } from '$lib/cookies';
+import { fetchPlayerFromApiUser, responseToPlayerArray } from '$lib/game/players';
+import { getUniverses, responseToUniverseArray } from '$lib/game/universes';
+import { fetchPlanetsFromPlayer, responseToPlanetArray } from '$lib/game/planets';
+
+export async function load({ cookies }) {
+	resetGameCookies(cookies);
+
+	const universesResponse = await getUniverses();
+
+	if (universesResponse.error()) {
+		error(404, { message: universesResponse.failureMessage() });
+	}
+
+	const universes = responseToUniverseArray(universesResponse);
+
+	return {
+		universes: universes.map((u) => u.toJson())
+	};
+}
+
+export const actions = {
+	login: async ({ cookies, request }) => {
+		const [valid, sessionCookies] = loadSessionCookies(cookies);
+		if (!valid) {
+			redirect(303, '/login');
+		}
+
+		const data = await request.formData();
+
+		const universeId = data.get('universe');
+		const playerName = data.get('player');
+		if (!universeId) {
+			return {
+				success: false,
+				missing: true,
+				message: 'Please select a universe'
+			};
+		}
+		if (!playerName) {
+			return {
+				success: false,
+				missing: true,
+				message: 'Please choose a name'
+			};
+		}
+
+		const playerResponse = await fetchPlayerFromApiUser(
+			sessionCookies.apiUser,
+			sessionCookies.apiKey
+		);
+		if (playerResponse.error()) {
+			return {
+				success: false,
+				incorrect: true,
+				message: playerResponse.failureMessage()
+			};
+		}
+
+		const players = responseToPlayerArray(playerResponse);
+		const maybePlayer = players.find(
+			(player) => player.universe === universeId && player.name === playerName
+		);
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
+		if (maybePlayer === undefined) {
+			return {
+				success: false,
+				incorrect: true,
+				message: 'No such player'
+			};
+		}
+
+		const planetsResponse = await fetchPlanetsFromPlayer(maybePlayer.id, sessionCookies.apiKey);
+		if (planetsResponse.error()) {
+			return {
+				success: false,
+				incorrect: true,
+				message: planetsResponse.failureMessage()
+			};
+		}
+
+		const planets = responseToPlanetArray(planetsResponse);
+
+		// https://stackoverflow.com/questions/35605548/get-first-object-from-array
+		const [maybePlanet] = planets;
+
+		if (maybePlanet === undefined) {
+			return {
+				success: false,
+				incorrect: true,
+				message: 'Player does not have any planet'
+			};
+		}
+
+		setGameCookies(cookies, maybePlayer);
+
+		redirect(303, '/planets/' + maybePlanet.id + '/overview');
+	}
+};

--- a/frontend/galactic-sovereign-frontend/src/routes/lobby/login/+page.svelte
+++ b/frontend/galactic-sovereign-frontend/src/routes/lobby/login/+page.svelte
@@ -14,6 +14,8 @@
 
 	export let form: HTMLFormElement;
 
+	export let data;
+
 	function resetFormError() {
 		if (!form) {
 			return;
@@ -28,39 +30,35 @@
 <FlexContainer>
 	<div class="fixed left-4 top-4">
 		<p class="text-secondary">
-			Don't have an account yet? Click <StyledLink text="here" link="/signup" /> to sign-up!
+			Back to the <StyledLink text="lobby" link="/lobby" />
 		</p>
 	</div>
 
 	<FlexContainer extensible={false} styling="h-1/5">
 		<StyledTitle text="Galactic Sovereign" />
-		<StyledText text="Login" />
+		<StyledText text="Resume existing session" />
 	</FlexContainer>
 
 	<FlexContainer extensible={false} styling="h-3/5">
 		<form method="POST" action="?/login" class="flex flex-col flex-1 justify-evenly">
-			<FormField label="email:" labelId="email">
-				<input
-					id="email"
-					type="text"
-					name="email"
-					placeholder="Enter your email address"
-					required
-					value={form?.email ?? ''}
-					on:input={resetFormError}
-				/>
+			<FormField label="universe:" labelId="universe">
+				<select id="universe" name="universe">
+					{#each data.universes as universe}
+						<option value={universe.id}>{universe.name}</option>
+					{/each}
+				</select>
 			</FormField>
-			<FormField label="password:" labelId="password">
+			<FormField label="player:" labelId="player">
 				<input
-					id="password"
+					id="player"
 					type="text"
-					name="password"
-					placeholder="Enter your password"
+					name="player"
+					placeholder="Choose a name"
 					required
 					on:input={resetFormError}
 				/></FormField
 			>
-			<StyledButton text="Login" />
+			<StyledButton text="Play" />
 		</form>
 
 		{#if form?.message}

--- a/frontend/galactic-sovereign-frontend/src/routes/lobby/register/+page.server.ts
+++ b/frontend/galactic-sovereign-frontend/src/routes/lobby/register/+page.server.ts
@@ -1,0 +1,86 @@
+import { error, redirect } from '@sveltejs/kit';
+import { resetGameCookies, setGameCookies, loadSessionCookies } from '$lib/cookies';
+import { Player, createPlayer } from '$lib/game/players';
+import { getUniverses, responseToUniverseArray } from '$lib/game/universes';
+import { fetchPlanetsFromPlayer, responseToPlanetArray } from '$lib/game/planets';
+
+export async function load({ cookies }) {
+	resetGameCookies(cookies);
+
+	const universesResponse = await getUniverses();
+
+	if (universesResponse.error()) {
+		error(404, { message: universesResponse.failureMessage() });
+	}
+
+	const universes = responseToUniverseArray(universesResponse);
+
+	return {
+		universes: universes.map((u) => u.toJson())
+	};
+}
+
+export const actions = {
+	register: async ({ cookies, request }) => {
+		const [valid, sessionCookies] = loadSessionCookies(cookies);
+		if (!valid) {
+			redirect(303, '/login');
+		}
+
+		const data = await request.formData();
+
+		const universeId = data.get('universe');
+		const playerName = data.get('player');
+		if (!universeId) {
+			return {
+				success: false,
+				missing: true,
+				message: 'Please select a universe'
+			};
+		}
+		if (!playerName) {
+			return {
+				success: false,
+				missing: true,
+				message: 'Please choose a name'
+			};
+		}
+
+		const playerResponse = await createPlayer(
+			sessionCookies.apiUser,
+			universeId as string,
+			playerName as string,
+			sessionCookies.apiKey
+		);
+		if (playerResponse.error()) {
+			return playerResponse;
+		}
+
+		const player = new Player(playerResponse.details);
+
+		const planetsResponse = await fetchPlanetsFromPlayer(player.id, sessionCookies.apiKey);
+		if (planetsResponse.error()) {
+			return {
+				success: false,
+				incorrect: true,
+				message: planetsResponse.failureMessage()
+			};
+		}
+
+		const planets = responseToPlanetArray(planetsResponse);
+
+		const [maybePlanet] = planets;
+
+		if (maybePlanet === undefined) {
+			return {
+				success: false,
+				incorrect: true,
+				message: 'Player does not have any planet'
+			};
+		}
+
+		setGameCookies(cookies, player);
+
+		redirect(303, '/planets/' + maybePlanet.id + '/overview');
+	}
+};

--- a/frontend/galactic-sovereign-frontend/src/routes/lobby/register/+page.svelte
+++ b/frontend/galactic-sovereign-frontend/src/routes/lobby/register/+page.svelte
@@ -14,6 +14,8 @@
 
 	export let form: HTMLFormElement;
 
+	export let data;
+
 	function resetFormError() {
 		if (!form) {
 			return;
@@ -28,44 +30,40 @@
 <FlexContainer>
 	<div class="fixed left-4 top-4">
 		<p class="text-secondary">
-			Don't have an account yet? Click <StyledLink text="here" link="/signup" /> to sign-up!
+			Back to the <StyledLink text="lobby" link="/lobby" />
 		</p>
 	</div>
 
 	<FlexContainer extensible={false} styling="h-1/5">
 		<StyledTitle text="Galactic Sovereign" />
-		<StyledText text="Login" />
+		<StyledText text="Join new universe" />
 	</FlexContainer>
 
 	<FlexContainer extensible={false} styling="h-3/5">
-		<form method="POST" action="?/login" class="flex flex-col flex-1 justify-evenly">
-			<FormField label="email:" labelId="email">
-				<input
-					id="email"
-					type="text"
-					name="email"
-					placeholder="Enter your email address"
-					required
-					value={form?.email ?? ''}
-					on:input={resetFormError}
-				/>
+		<form method="POST" action="?/register" class="flex flex-col flex-1 justify-evenly">
+			<FormField label="universe:" labelId="universe">
+				<select id="universe" name="universe">
+					{#each data.universes as universe}
+						<option value={universe.id}>{universe.name}</option>
+					{/each}
+				</select>
 			</FormField>
-			<FormField label="password:" labelId="password">
+			<FormField label="player:" labelId="player">
 				<input
-					id="password"
+					id="player"
 					type="text"
-					name="password"
-					placeholder="Enter your password"
+					name="player"
+					placeholder="Choose a name"
 					required
 					on:input={resetFormError}
 				/></FormField
 			>
-			<StyledButton text="Login" />
+			<StyledButton text="Start" />
 		</form>
 
 		{#if form?.message}
 			<div class="fixed bottom-4">
-				<StyledError text="Failed to login: {form.message}" />
+				<StyledError text="Failed to register in universe: {form.message}" />
 			</div>
 		{/if}
 	</FlexContainer>

--- a/frontend/galactic-sovereign-frontend/src/routes/planets/[planet=id]/buildings/+page.server.ts
+++ b/frontend/galactic-sovereign-frontend/src/routes/planets/[planet=id]/buildings/+page.server.ts
@@ -4,6 +4,7 @@ import { loadCookies } from '$lib/cookies';
 import { ApiFailureReason } from '$lib/responseEnvelope.js';
 
 import { logout } from '$lib/actions/logout';
+import { backToLobby } from '$lib/actions/backToLobby';
 import {
 	requestCreateBuildingAction,
 	requestDeleteBuildingAction
@@ -21,7 +22,7 @@ export async function load({ params, cookies, depends }) {
 	// https://learn.svelte.dev/tutorial/custom-dependencies
 	depends('data:planet');
 
-	const planetResponse = await getPlanet(gameCookies.apiKey, params.planet);
+	const planetResponse = await getPlanet(gameCookies.session.apiKey, params.planet);
 	if (planetResponse.error()) {
 		const reason = planetResponse.failureReason();
 
@@ -58,6 +59,7 @@ export async function load({ params, cookies, depends }) {
 
 export const actions = {
 	logout: logout,
+	backToLobby: backToLobby,
 	createBuildingAction: requestCreateBuildingAction,
 	deleteBuildingAction: requestDeleteBuildingAction
 };

--- a/frontend/galactic-sovereign-frontend/src/routes/planets/[planet=id]/overview/+page.server.ts
+++ b/frontend/galactic-sovereign-frontend/src/routes/planets/[planet=id]/overview/+page.server.ts
@@ -4,6 +4,7 @@ import { loadCookies } from '$lib/cookies';
 import { ApiFailureReason } from '$lib/responseEnvelope.js';
 
 import { logout } from '$lib/actions/logout';
+import { backToLobby } from '$lib/actions/backToLobby';
 import { requestDeleteBuildingAction } from '$lib/actions/buildingAction';
 
 import { Universe, type ApiUniverse, getUniverse } from '$lib/game/universes';
@@ -18,7 +19,7 @@ export async function load({ params, cookies, depends }) {
 	// https://learn.svelte.dev/tutorial/custom-dependencies
 	depends('data:planet');
 
-	const planetResponse = await getPlanet(gameCookies.apiKey, params.planet);
+	const planetResponse = await getPlanet(gameCookies.session.apiKey, params.planet);
 	if (planetResponse.error()) {
 		const reason = planetResponse.failureReason();
 
@@ -55,5 +56,6 @@ export async function load({ params, cookies, depends }) {
 
 export const actions = {
 	logout: logout,
+	backToLobby: backToLobby,
 	deleteBuildingAction: requestDeleteBuildingAction
 };

--- a/frontend/galactic-sovereign-frontend/src/routes/signup/+page.svelte
+++ b/frontend/galactic-sovereign-frontend/src/routes/signup/+page.svelte
@@ -14,8 +14,6 @@
 
 	export let form: HTMLFormElement;
 
-	export let data;
-
 	function resetFormError() {
 		if (!form) {
 			return;
@@ -41,13 +39,6 @@
 
 	<FlexContainer extensible={false} styling="h-3/5">
 		<form method="POST" action="?/signup" class="flex flex-col flex-1 justify-evenly">
-			<FormField label="universe:" labelId="universe">
-				<select id="universe" name="universe">
-					{#each data.universes as universe}
-						<option value={universe.id}>{universe.name}</option>
-					{/each}
-				</select>
-			</FormField>
 			<FormField label="email:" labelId="email">
 				<input
 					id="email"
@@ -65,16 +56,6 @@
 					type="text"
 					name="password"
 					placeholder="Enter your password"
-					required
-					on:input={resetFormError}
-				/></FormField
-			>
-			<FormField label="player:" labelId="player">
-				<input
-					id="player"
-					type="text"
-					name="player"
-					placeholder="Choose a name"
 					required
 					on:input={resetFormError}
 				/></FormField


### PR DESCRIPTION
# Work

## What is the current situation?
Up until this PR, the sign-up workflow was designed as follow:
* the user picks a universe, an email, a password and a name
* we create the user (from the email and the password)
* we login the user (as the other routes require authentication)
* we create the player (from the universe and name)
* we logout the user

## Is this good enough?
This is cumbersome for multiple reasons:
* in case the creation of the user succeeds but the rest does not, the email can't be used again as the user already exists
* in case the user wants to join multiple universes, they have to use a different email each time

In addition, there's no way for the user to see which sessions they already have.

## How to fix it?
Most often for games where you can play on multiple servers, there's a concept of an account and players: the account is the unique entry point of each user. It uses (usually) an email address and a password and grants access to a 'lobby'. This is usually a space where the user is not in-game yet but is already authenticated with the server.

Once in the lobby, there's usually a panel to select which player to continue the adventure with (in our case this means picking the universe in which the user wants to log into). This looks like the following for OGame:

![Screenshot from 2024-10-26 10-23-56](https://github.com/user-attachments/assets/01b529cf-8d59-4bb8-813a-c5f0d0831a9b)

## What was done?
In this PR we added support for:
* change to the login flow to only [create a user](https://github.com/Knoblauchpilze/galactic-sovereign/pull/21/files#diff-6c9324226ed5a28d1f8f376e9b9367f0d97afb336e1efa21a251059438f8fbccL77-R34) on sign-up.
* only require the [email and password](https://github.com/Knoblauchpilze/galactic-sovereign/pull/21/files#diff-9a013ed1552d5aa5fa37181aa62ac99653a787849840149681797ec64300ae7eL44-L50) on sign-up and not the universe and the player name.
* a differentiation between the [session cookies](https://github.com/Knoblauchpilze/galactic-sovereign/pull/21/files#diff-006b6cbc0982b5757b72cbffd033f82ba6271f643ae032516c381d4b7652604eR60) (corresponding to the authentication) and the [game cookies](https://github.com/Knoblauchpilze/galactic-sovereign/pull/21/files#diff-006b6cbc0982b5757b72cbffd033f82ba6271f643ae032516c381d4b7652604eR81) (corresponding to the actual session the user is playing).
* a [lobby page](https://github.com/Knoblauchpilze/galactic-sovereign/pull/21/files#diff-14d1e7e079d28d2a989a169eb09c20bb64f206f788f2bd7e31971e7bd1aa94ffR23) which proposes two options: either resume an existing session or join a new universe.
* the lobby page allows to [logout](https://github.com/Knoblauchpilze/galactic-sovereign/pull/21/files#diff-14d1e7e079d28d2a989a169eb09c20bb64f206f788f2bd7e31971e7bd1aa94ffR14) and return to the home page.
* added a [back to lobby](https://github.com/Knoblauchpilze/galactic-sovereign/pull/21/files#diff-2448698ba6933bab99cd4be5b51a5f881fbe22fb5681a87d072212eeb2631fbbR34-R36) button in the game pages to not logout completely if desired.

# Tests

The testing is mainly done manually for now.

The login/sign-up pages are simpler now:

![image](https://github.com/user-attachments/assets/f6ae7315-fb7c-47d1-a1e1-abd9e9dba6f8)

The new lobby page:

![image](https://github.com/user-attachments/assets/293c2393-2264-4ba2-a0af-2f5c167eecf4)

The page to resume an existing session:

![image](https://github.com/user-attachments/assets/31436209-90d2-4af6-9149-7564d3ad71bc)

The game pages allow to go back to the lobby:

![image](https://github.com/user-attachments/assets/c570a27c-1667-4750-b836-4a607ed20538)

# Future work

There are a couple of things that we still need to tackle. Some of them are detailed below.

## Only show relevant universes in the lobby

Ideally, we would like to only display the universes that are relevant in the lobby. Specifically:
   * only universes where the user is not registered yet in the `register` page.
   * only universes where the user is registered in the `login` page.

Additionally, we could make the interface more user-friendly by showing some cards with the universe and the name instead of a drop down list for the `login` case.

## Authentication

For each route defined in our service, we have to define whether they are [authorized](https://github.com/Knoblauchpilze/galactic-sovereign/blob/master/pkg/rest/route.go#L22) or not. This stems from the fact that with a sign-up/login flow that requires the list of universes, we had to make sure that at least the `v1/universes` route was accessible. This might not be necessary anymore due to the proper login flow. Now all the routes from the `galactic-sovereign` project can be made private and only accessible after authentication.

## Subdomains

As we expand the services and possibly games served on the website, the lobby page might become more of a redirection tool where users can pick the game they want to play and then be redirected to the game's page. To facilitate this, we could move the `galactic-sovereign` game to `galactic-sovereign.gasetropo.de`.

This would also allow to easily have separate services to handle each subdomain and extract the lobby as its own service as well.
