### PR TITLE
feat: Refactored galactic-sovereign routes

### DIFF
--- a/.github/workflows/galactic-sovereign-frontend-build-and-push.yml
+++ b/.github/workflows/galactic-sovereign-frontend-build-and-push.yml
@@ -35,7 +35,7 @@ jobs:
           file: ./build/galactic-sovereign-frontend/Dockerfile
           build-args: |
             GIT_COMMIT_HASH=${{ needs.extract-service-tag.outputs.version }}
-            API_BASE_URL=http://galactic-sovereign-service:80/v1
+            API_BASE_URL=http://galactic-sovereign-service:80/v1/galactic-sovereign
             USER_API_BASE_URL=http://user-service:80/v1/users
           push: true
           tags: totocorpsoftwareinc/galactic-sovereign-frontend:${{ needs.extract-service-tag.outputs.version }}

--- a/build/galactic-sovereign-frontend/Dockerfile
+++ b/build/galactic-sovereign-frontend/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:22 AS builder
-ARG API_BASE_URL="http://galactic-sovereign-service:80/v1"
+ARG API_BASE_URL="http://galactic-sovereign-service:80/v1/galactic-sovereign"
 ARG USER_API_BASE_URL="http://user-service:80/v1/users"
 WORKDIR /build
 COPY frontend/galactic-sovereign-frontend ./

--- a/cmd/galactic-sovereign/internal/config.go
+++ b/cmd/galactic-sovereign/internal/config.go
@@ -6,6 +6,7 @@ import (
 
 func DefaultConf() config.Configuration {
 	conf := config.DefaultConf()
+	conf.Server.Prefix = "/galactic-sovereign"
 	conf.Database.Name = "db_galactic_sovereign"
 	return conf
 }

--- a/cmd/galactic-sovereign/internal/config_test.go
+++ b/cmd/galactic-sovereign/internal/config_test.go
@@ -11,13 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDefaultConfig_LeavesServerUnchanged(t *testing.T) {
+func TestDefaultConfig_SetsCorrectPrefix(t *testing.T) {
 	assert := assert.New(t)
 
 	conf := DefaultConf()
 
 	expected := rest.Config{
 		BasePath:  "/v1",
+		Prefix:    "/galactic-sovereign",
 		Port:      uint16(80),
 		RateLimit: 10,
 	}

--- a/deployments/config/galactic-sovereign-service.yml
+++ b/deployments/config/galactic-sovereign-service.yml
@@ -3,21 +3,11 @@ http:
     galactic-sovereign-service-https:
       entryPoints:
         - "websecure"
-      rule: 'Host(`api.{{ env "DOMAIN_NAME" }}`) && PathPrefix(`/v1`)'
+      rule: 'Host(`api.{{ env "DOMAIN_NAME" }}`) && PathPrefix(`/v1/galactic-sovereign`)'
       service: galactic-sovereign-service
       middlewares:
         - "rate-limit"
         - "auth"
-      tls:
-        certResolver: letsencryptresolver
-
-    galactic-sovereign-service-public-https:
-      entryPoints:
-        - "websecure"
-      rule: 'Host(`api.{{ env "DOMAIN_NAME" }}`) && PathPrefix(`/v1/universes`)'
-      service: galactic-sovereign-service
-      middlewares:
-        - "rate-limit"
       tls:
         certResolver: letsencryptresolver
 
@@ -40,4 +30,4 @@ http:
         servers:
           - url: "http://galactic-sovereign-service:80"
         healthCheck:
-          path: /v1/healthcheck
+          path: /v1/galactic-sovereign/healthcheck

--- a/frontend/galactic-sovereign-frontend/.env-example.local
+++ b/frontend/galactic-sovereign-frontend/.env-example.local
@@ -1,2 +1,2 @@
-PUBLIC_API_BASE_URL="http://localhost:60002/v1"
+PUBLIC_API_BASE_URL="http://localhost:60002/v1/galactic-sovereign"
 PUBLIC_USER_API_BASE_URL="http://localhost:60001/v1/users"

--- a/frontend/galactic-sovereign-frontend/src/lib/game/universes.ts
+++ b/frontend/galactic-sovereign-frontend/src/lib/game/universes.ts
@@ -45,7 +45,7 @@ export async function getUniverse(id: string): Promise<ResponseEnvelope> {
 	const url = buildUrl('universes/' + id);
 
 	const params = {
-		method: 'GET',
+		method: 'GET'
 	};
 
 	const response = await safeFetch(url, params);
@@ -54,11 +54,14 @@ export async function getUniverse(id: string): Promise<ResponseEnvelope> {
 	return new ResponseEnvelope(jsonContent);
 }
 
-export async function getUniverses(): Promise<ResponseEnvelope> {
+export async function getUniverses(apiKey: string): Promise<ResponseEnvelope> {
 	const url = buildUrl('universes');
 
 	const params = {
-		method: 'GET'
+		method: 'GET',
+		headers: {
+			'X-Api-Key': apiKey
+		}
 	};
 
 	const response = await safeFetch(url, params);

--- a/frontend/galactic-sovereign-frontend/src/routes/lobby/login/+page.server.ts
+++ b/frontend/galactic-sovereign-frontend/src/routes/lobby/login/+page.server.ts
@@ -7,7 +7,12 @@ import { fetchPlanetsFromPlayer, responseToPlanetArray } from '$lib/game/planets
 export async function load({ cookies }) {
 	resetGameCookies(cookies);
 
-	const universesResponse = await getUniverses();
+	const [valid, sessionCookies] = loadSessionCookies(cookies);
+	if (!valid) {
+		redirect(303, '/login');
+	}
+
+	const universesResponse = await getUniverses(sessionCookies.apiKey);
 
 	if (universesResponse.error()) {
 		error(404, { message: universesResponse.failureMessage() });

--- a/frontend/galactic-sovereign-frontend/src/routes/lobby/register/+page.server.ts
+++ b/frontend/galactic-sovereign-frontend/src/routes/lobby/register/+page.server.ts
@@ -7,7 +7,12 @@ import { fetchPlanetsFromPlayer, responseToPlanetArray } from '$lib/game/planets
 export async function load({ cookies }) {
 	resetGameCookies(cookies);
 
-	const universesResponse = await getUniverses();
+	const [valid, sessionCookies] = loadSessionCookies(cookies);
+	if (!valid) {
+		redirect(303, '/login');
+	}
+
+	const universesResponse = await getUniverses(sessionCookies.apiKey);
 
 	if (universesResponse.error()) {
 		error(404, { message: universesResponse.failureMessage() });


### PR DESCRIPTION
# Work

As mentioned in #21 we would like to rework how the authentication is used in our cluster. We started in #22 to expose some possibilities to configure a base prefix for a service.

In this PR we continue the work to group the routes of the `galactic-sovereign-service` under a unique prefix. This means that instead of reaching `/v1/universes`, we can reach the service under `/v1/galactic-sovereign/universes`.

With the rework of the login/sign-up workflow we can also remove the public router allowing to access `/v1/universes` publicly: now all the routes for the `galactic-sovereign-service` are only accessible with a valid API key.

# Tests

Similar to what was done in #21 we changed the monitoring endpoint for the `galactic-sovereign-service` was changed on the instance.

# Future work

We could improve even further the flow by not requiring the `user-service` to define a server with API key: instead we could rely on some configuration from traefik to handle the logic.
