### PR TITLE
feat: Routes do not require authorization anymore

### DIFF
--- a/cmd/users/main.go
+++ b/cmd/users/main.go
@@ -57,7 +57,7 @@ func main() {
 	userService := service.NewUserService(conf.ApiKey, pool, repos)
 	authService := service.NewAuthService(pool, repos)
 
-	s := rest.NewServerWithApiKey(conf.Server, repos.ApiKey)
+	s := rest.NewServer(conf.Server)
 
 	for _, route := range controller.UserEndpoints(userService) {
 		if err := s.Register(route); err != nil {

--- a/internal/controller/auth.go
+++ b/internal/controller/auth.go
@@ -18,7 +18,7 @@ func AuthEndpoints(service service.AuthService) rest.Routes {
 	var out rest.Routes
 
 	authHandler := fromAuthServiceAwareHttpHandler(authUser, service)
-	auth := rest.NewRoute(http.MethodGet, false, "/auth", authHandler)
+	auth := rest.NewRoute(http.MethodGet, "/auth", authHandler)
 	out = append(out, auth)
 
 	return out

--- a/internal/controller/building_action.go
+++ b/internal/controller/building_action.go
@@ -25,7 +25,7 @@ func BuildingActionEndpoints(buildingActionService service.BuildingActionService
 	out = append(out, post)
 
 	deleteHandler := fromBuildingActionServiceAwareHttpHandler(deleteBuildingAction, buildingActionService)
-	delete := rest.NewResourceRoute(http.MethodDelete, false, "/actions", deleteHandler)
+	delete := game.NewResourceRoute(http.MethodDelete, "/actions", deleteHandler, actionService, planetResourceService)
 	out = append(out, delete)
 
 	return out

--- a/internal/controller/health_check.go
+++ b/internal/controller/health_check.go
@@ -13,7 +13,7 @@ func HealthCheckEndpoints(pool db.ConnectionPool) rest.Routes {
 	var out rest.Routes
 
 	getHandler := fromDbAwareHttpHandler(healthcheck, pool)
-	get := rest.NewRoute(http.MethodGet, false, "/healthcheck", getHandler)
+	get := rest.NewRoute(http.MethodGet, "/healthcheck", getHandler)
 	out = append(out, get)
 
 	return out

--- a/internal/controller/planets.go
+++ b/internal/controller/planets.go
@@ -19,7 +19,7 @@ func PlanetEndpoints(planetService service.PlanetService,
 	var out rest.Routes
 
 	postHandler := fromPlanetServiceAwareHttpHandler(createPlanet, planetService)
-	post := rest.NewRoute(http.MethodPost, false, "/planets", postHandler)
+	post := rest.NewRoute(http.MethodPost, "/planets", postHandler)
 	out = append(out, post)
 
 	getHandler := fromPlanetServiceAwareHttpHandler(getPlanet, planetService)
@@ -27,7 +27,7 @@ func PlanetEndpoints(planetService service.PlanetService,
 	out = append(out, get)
 
 	listHandler := fromPlanetServiceAwareHttpHandler(listPlanets, planetService)
-	list := rest.NewRoute(http.MethodGet, false, "/planets", listHandler)
+	list := rest.NewRoute(http.MethodGet, "/planets", listHandler)
 	out = append(out, list)
 
 	deleteHandler := fromPlanetServiceAwareHttpHandler(deletePlanet, planetService)

--- a/internal/controller/players.go
+++ b/internal/controller/players.go
@@ -16,19 +16,19 @@ func PlayerEndpoints(service service.PlayerService) rest.Routes {
 	var out rest.Routes
 
 	postHandler := fromPlayerServiceAwareHttpHandler(createPlayer, service)
-	post := rest.NewRoute(http.MethodPost, false, "/players", postHandler)
+	post := rest.NewRoute(http.MethodPost, "/players", postHandler)
 	out = append(out, post)
 
 	getHandler := fromPlayerServiceAwareHttpHandler(getPlayer, service)
-	get := rest.NewResourceRoute(http.MethodGet, false, "/players", getHandler)
+	get := rest.NewResourceRoute(http.MethodGet, "/players", getHandler)
 	out = append(out, get)
 
 	listHandler := fromPlayerServiceAwareHttpHandler(listPlayers, service)
-	list := rest.NewRoute(http.MethodGet, false, "/players", listHandler)
+	list := rest.NewRoute(http.MethodGet, "/players", listHandler)
 	out = append(out, list)
 
 	deleteHandler := fromPlayerServiceAwareHttpHandler(deletePlayer, service)
-	delete := rest.NewResourceRoute(http.MethodDelete, false, "/players", deleteHandler)
+	delete := rest.NewResourceRoute(http.MethodDelete, "/players", deleteHandler)
 	out = append(out, delete)
 
 	return out

--- a/internal/controller/universes.go
+++ b/internal/controller/universes.go
@@ -16,19 +16,19 @@ func UniverseEndpoints(service service.UniverseService) rest.Routes {
 	var out rest.Routes
 
 	postHandler := fromUniverseServiceAwareHttpHandler(createUniverse, service)
-	post := rest.NewRoute(http.MethodPost, false, "/universes", postHandler)
+	post := rest.NewRoute(http.MethodPost, "/universes", postHandler)
 	out = append(out, post)
 
 	getHandler := fromUniverseServiceAwareHttpHandler(getUniverse, service)
-	get := rest.NewResourceRoute(http.MethodGet, false, "/universes", getHandler)
+	get := rest.NewResourceRoute(http.MethodGet, "/universes", getHandler)
 	out = append(out, get)
 
 	listHandler := fromUniverseServiceAwareHttpHandler(listUniverses, service)
-	list := rest.NewRoute(http.MethodGet, false, "/universes", listHandler)
+	list := rest.NewRoute(http.MethodGet, "/universes", listHandler)
 	out = append(out, list)
 
 	deleteHandler := fromUniverseServiceAwareHttpHandler(deleteUniverse, service)
-	delete := rest.NewResourceRoute(http.MethodDelete, false, "/universes", deleteHandler)
+	delete := rest.NewResourceRoute(http.MethodDelete, "/universes", deleteHandler)
 	out = append(out, delete)
 
 	return out

--- a/internal/controller/users.go
+++ b/internal/controller/users.go
@@ -16,35 +16,35 @@ func UserEndpoints(service service.UserService) rest.Routes {
 	var out rest.Routes
 
 	postHandler := fromUserServiceAwareHttpHandler(createUser, service)
-	post := rest.NewRoute(http.MethodPost, false, "/", postHandler)
+	post := rest.NewRoute(http.MethodPost, "/", postHandler)
 	out = append(out, post)
 
 	getHandler := fromUserServiceAwareHttpHandler(getUser, service)
-	get := rest.NewResourceRoute(http.MethodGet, true, "/", getHandler)
+	get := rest.NewResourceRoute(http.MethodGet, "/", getHandler)
 	out = append(out, get)
 
 	listHandler := fromUserServiceAwareHttpHandler(listUsers, service)
-	list := rest.NewRoute(http.MethodGet, true, "/", listHandler)
+	list := rest.NewRoute(http.MethodGet, "/", listHandler)
 	out = append(out, list)
 
 	updateHandler := fromUserServiceAwareHttpHandler(updateUser, service)
-	update := rest.NewResourceRoute(http.MethodPatch, true, "/", updateHandler)
+	update := rest.NewResourceRoute(http.MethodPatch, "/", updateHandler)
 	out = append(out, update)
 
 	deleteHandler := fromUserServiceAwareHttpHandler(deleteUser, service)
-	delete := rest.NewResourceRoute(http.MethodDelete, true, "/", deleteHandler)
+	delete := rest.NewResourceRoute(http.MethodDelete, "/", deleteHandler)
 	out = append(out, delete)
 
 	loginByEmailHandler := fromUserServiceAwareHttpHandler(loginUserByEmail, service)
-	loginByEmail := rest.NewRoute(http.MethodPost, false, "/sessions", loginByEmailHandler)
+	loginByEmail := rest.NewRoute(http.MethodPost, "/sessions", loginByEmailHandler)
 	out = append(out, loginByEmail)
 
 	loginByIdHandler := fromUserServiceAwareHttpHandler(loginUserById, service)
-	loginById := rest.NewResourceRoute(http.MethodPost, false, "/sessions", loginByIdHandler)
+	loginById := rest.NewResourceRoute(http.MethodPost, "/sessions", loginByIdHandler)
 	out = append(out, loginById)
 
 	logoutHandler := fromUserServiceAwareHttpHandler(logoutUser, service)
-	logout := rest.NewResourceRoute(http.MethodDelete, true, "/sessions", logoutHandler)
+	logout := rest.NewResourceRoute(http.MethodDelete, "/sessions", logoutHandler)
 	out = append(out, logout)
 
 	return out

--- a/pkg/game/route.go
+++ b/pkg/game/route.go
@@ -11,7 +11,7 @@ func NewRoute(method string,
 	actionService ActionService,
 	planetResourceService PlanetResourceService) rest.Route {
 	wrapped := GameUpdateWatcher(actionService, planetResourceService, handler)
-	return rest.NewRoute(method, false, path, wrapped)
+	return rest.NewRoute(method, path, wrapped)
 }
 
 func NewResourceRoute(method string,
@@ -20,5 +20,5 @@ func NewResourceRoute(method string,
 	actionService ActionService,
 	planetResourceService PlanetResourceService) rest.Route {
 	wrapped := GameUpdateWatcher(actionService, planetResourceService, handler)
-	return rest.NewResourceRoute(method, false, path, wrapped)
+	return rest.NewResourceRoute(method, path, wrapped)
 }

--- a/pkg/rest/route.go
+++ b/pkg/rest/route.go
@@ -25,20 +25,40 @@ type routeImpl struct {
 	handler     echo.HandlerFunc
 }
 
-func NewRoute(method string, authorized bool, path string, handler echo.HandlerFunc) Route {
+func NewRoute(method string, path string, handler echo.HandlerFunc) Route {
 	return &routeImpl{
 		method:      method,
-		authorized:  authorized,
+		authorized:  false,
 		path:        sanitizePath(path),
 		addIdInPath: false,
 		handler:     handler,
 	}
 }
 
-func NewResourceRoute(method string, authorized bool, path string, handler echo.HandlerFunc) Route {
+func NewAuthorizedRoute(method string, path string, handler echo.HandlerFunc) Route {
 	return &routeImpl{
 		method:      method,
-		authorized:  authorized,
+		authorized:  true,
+		path:        sanitizePath(path),
+		addIdInPath: false,
+		handler:     handler,
+	}
+}
+
+func NewResourceRoute(method string, path string, handler echo.HandlerFunc) Route {
+	return &routeImpl{
+		method:      method,
+		authorized:  false,
+		path:        sanitizePath(path),
+		addIdInPath: true,
+		handler:     handler,
+	}
+}
+
+func NewAuthorizedResourceRoute(method string, path string, handler echo.HandlerFunc) Route {
+	return &routeImpl{
+		method:      method,
+		authorized:  true,
 		path:        sanitizePath(path),
 		addIdInPath: true,
 		handler:     handler,

--- a/pkg/rest/route_test.go
+++ b/pkg/rest/route_test.go
@@ -14,34 +14,34 @@ var defaultHandler = func(c echo.Context) error { return nil }
 func TestRoute_Method(t *testing.T) {
 	assert := assert.New(t)
 
-	r := NewRoute(http.MethodGet, false, "", defaultHandler)
+	r := NewRoute(http.MethodGet, "", defaultHandler)
 	assert.Equal(http.MethodGet, r.Method())
 }
 
 func TestRoute_WithResource_Method(t *testing.T) {
 	assert := assert.New(t)
 
-	r := NewResourceRoute(http.MethodGet, false, "", defaultHandler)
+	r := NewResourceRoute(http.MethodGet, "", defaultHandler)
 	assert.Equal(http.MethodGet, r.Method())
 }
 
 func TestRoute_Authorized(t *testing.T) {
 	assert := assert.New(t)
 
-	public := NewRoute(http.MethodGet, false, "", defaultHandler)
+	public := NewRoute(http.MethodGet, "", defaultHandler)
 	assert.Equal(false, public.Authorized())
 
-	authorized := NewRoute(http.MethodGet, true, "", defaultHandler)
+	authorized := NewAuthorizedRoute(http.MethodGet, "", defaultHandler)
 	assert.Equal(true, authorized.Authorized())
 }
 
 func TestRoute_WithResource_Authorized(t *testing.T) {
 	assert := assert.New(t)
 
-	public := NewResourceRoute(http.MethodGet, false, "", defaultHandler)
+	public := NewResourceRoute(http.MethodGet, "", defaultHandler)
 	assert.Equal(false, public.Authorized())
 
-	authorized := NewResourceRoute(http.MethodGet, true, "", defaultHandler)
+	authorized := NewAuthorizedResourceRoute(http.MethodGet, "", defaultHandler)
 	assert.Equal(true, authorized.Authorized())
 }
 
@@ -54,7 +54,7 @@ func TestRoute_Handler(t *testing.T) {
 		return nil
 	}
 
-	r := NewRoute(http.MethodGet, false, "", handler)
+	r := NewRoute(http.MethodGet, "", handler)
 	actual := r.Handler()
 	actual(dummyEchoContext())
 
@@ -70,7 +70,7 @@ func TestRoute_WithResource_Handler(t *testing.T) {
 		return nil
 	}
 
-	r := NewResourceRoute(http.MethodGet, false, "", handler)
+	r := NewResourceRoute(http.MethodGet, "", handler)
 	actual := r.Handler()
 	actual(dummyEchoContext())
 
@@ -95,7 +95,7 @@ func TestRoute_Path(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
 
-			r := NewRoute(http.MethodGet, false, tc.path, defaultHandler)
+			r := NewRoute(http.MethodGet, tc.path, defaultHandler)
 			assert.Equal(tc.expected, r.Path())
 		})
 	}
@@ -114,7 +114,7 @@ func TestRoute_WithResource_GeneratePath(t *testing.T) {
 	for _, tc := range tests {
 		t.Run("", func(t *testing.T) {
 
-			r := NewResourceRoute(http.MethodGet, false, tc.path, defaultHandler)
+			r := NewResourceRoute(http.MethodGet, tc.path, defaultHandler)
 			assert.Equal(tc.expected, r.Path())
 		})
 	}
@@ -125,7 +125,7 @@ func TestRoute_WithResource_WhenIdPlaceHolderAlreadyExists_DoNotGeneratePath(t *
 
 	path := "/path/:id/addendum"
 
-	r := NewResourceRoute(http.MethodGet, false, path, defaultHandler)
+	r := NewResourceRoute(http.MethodGet, path, defaultHandler)
 
 	assert.Equal(path, r.Path())
 }


### PR DESCRIPTION
# Work

In #21 we agreed to let `traefik` handle the authentication logic. We worked towards this objective in #22, #23 and #24. What is left to do is to not create authorized routes in the `user-service`. Additionally, we don't want to register the API key middleware anymore as it does not serve any purpose. This PR achieves this goal.

# Tests

Testing locally we are able to access the routes of the `user-service` even without the API key.

# Future work

We can work on the additional tasks mentioned in the future work section of #21.
