### PR TITLE
Revert "chore(deps-dev): Bump @typescript-eslint/eslint-plugin from 7.8.0 to 8.15.0 in /frontend/user-dashboard"

### DIFF
--- a/frontend/user-dashboard/package-lock.json
+++ b/frontend/user-dashboard/package-lock.json
@@ -13,7 +13,7 @@
 				"@sveltejs/kit": "^2.8.1",
 				"@sveltejs/vite-plugin-svelte": "^4.0.1",
 				"@types/eslint": "^8.56.0",
-				"@typescript-eslint/eslint-plugin": "^8.15.0",
+				"@typescript-eslint/eslint-plugin": "^7.0.0",
 				"@typescript-eslint/parser": "^7.18.0",
 				"autoprefixer": "^10.4.20",
 				"eslint": "^8.56.0",
@@ -1216,32 +1216,40 @@
 			"integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
 			"dev": true
 		},
+		"node_modules/@types/semver": {
+			"version": "7.5.8",
+			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+			"integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+			"dev": true
+		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.15.0.tgz",
-			"integrity": "sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.8.0.tgz",
+			"integrity": "sha512-gFTT+ezJmkwutUPmB0skOj3GZJtlEGnlssems4AjkVweUPGj7jRwwqg0Hhg7++kPGJqKtTYx+R05Ftww372aIg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.15.0",
-				"@typescript-eslint/type-utils": "8.15.0",
-				"@typescript-eslint/utils": "8.15.0",
-				"@typescript-eslint/visitor-keys": "8.15.0",
+				"@typescript-eslint/scope-manager": "7.8.0",
+				"@typescript-eslint/type-utils": "7.8.0",
+				"@typescript-eslint/utils": "7.8.0",
+				"@typescript-eslint/visitor-keys": "7.8.0",
+				"debug": "^4.3.4",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
+				"semver": "^7.6.0",
 				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-				"eslint": "^8.57.0 || ^9.0.0"
+				"@typescript-eslint/parser": "^7.0.0",
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -1353,16 +1361,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.15.0.tgz",
-			"integrity": "sha512-QRGy8ADi4J7ii95xz4UoiymmmMd/zuy9azCaamnZ3FM8T5fZcex8UfJcjkiEZjJSztKfEBe3dZ5T/5RHAmw2mA==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.8.0.tgz",
+			"integrity": "sha512-viEmZ1LmwsGcnr85gIq+FCYI7nO90DVbE37/ll51hjv9aG+YZMb4WDE2fyWpUR4O/UrhGRpYXK/XajcGTk2B8g==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "8.15.0",
-				"@typescript-eslint/visitor-keys": "8.15.0"
+				"@typescript-eslint/types": "7.8.0",
+				"@typescript-eslint/visitor-keys": "7.8.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1370,25 +1378,25 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.15.0.tgz",
-			"integrity": "sha512-UU6uwXDoI3JGSXmcdnP5d8Fffa2KayOhUUqr/AiBnG1Gl7+7ut/oyagVeSkh7bxQ0zSXV9ptRh/4N15nkCqnpw==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.8.0.tgz",
+			"integrity": "sha512-H70R3AefQDQpz9mGv13Uhi121FNMh+WEaRqcXTX09YEDky21km4dV1ZXJIp8QjXc4ZaVkXVdohvWDzbnbHDS+A==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.15.0",
-				"@typescript-eslint/utils": "8.15.0",
+				"@typescript-eslint/typescript-estree": "7.8.0",
+				"@typescript-eslint/utils": "7.8.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0"
+				"eslint": "^8.56.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -1397,12 +1405,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.15.0.tgz",
-			"integrity": "sha512-n3Gt8Y/KyJNe0S3yDCD2RVKrHBC4gTUcLTebVBXacPy091E6tNspFLKRXlk3hwT4G55nfr1n2AdFqi/XMxzmPQ==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.8.0.tgz",
+			"integrity": "sha512-wf0peJ+ZGlcH+2ZS23aJbOv+ztjeeP8uQ9GgwMJGVLx/Nj9CJt17GWgWWoSmoRVKAX2X+7fzEnAjxdvK2gqCLw==",
 			"dev": true,
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1410,22 +1418,22 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.15.0.tgz",
-			"integrity": "sha512-1eMp2JgNec/niZsR7ioFBlsh/Fk0oJbhaqO0jRyQBMgkz7RrFfkqF9lYYmBoGBaSiLnu8TAPQTwoTUiSTUW9dg==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.8.0.tgz",
+			"integrity": "sha512-5pfUCOwK5yjPaJQNy44prjCwtr981dO8Qo9J9PwYXZ0MosgAbfEMB008dJ5sNo3+/BN6ytBPuSvXUg9SAqB0dg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "8.15.0",
-				"@typescript-eslint/visitor-keys": "8.15.0",
+				"@typescript-eslint/types": "7.8.0",
+				"@typescript-eslint/visitor-keys": "7.8.0",
 				"debug": "^4.3.4",
-				"fast-glob": "^3.3.2",
+				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
 				"minimatch": "^9.0.4",
 				"semver": "^7.6.0",
 				"ts-api-utils": "^1.3.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -1438,59 +1446,45 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.15.0.tgz",
-			"integrity": "sha512-k82RI9yGhr0QM3Dnq+egEpz9qB6Un+WLYhmoNcvl8ltMEededhh7otBVVIDDsEEttauwdY/hQoSsOv13lxrFzQ==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.8.0.tgz",
+			"integrity": "sha512-L0yFqOCflVqXxiZyXrDr80lnahQfSOfc9ELAAZ75sqicqp2i36kEZZGuUymHNFoYOqxRT05up760b4iGsl02nQ==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.15.0",
-				"@typescript-eslint/types": "8.15.0",
-				"@typescript-eslint/typescript-estree": "8.15.0"
+				"@types/json-schema": "^7.0.15",
+				"@types/semver": "^7.5.8",
+				"@typescript-eslint/scope-manager": "7.8.0",
+				"@typescript-eslint/types": "7.8.0",
+				"@typescript-eslint/typescript-estree": "7.8.0",
+				"semver": "^7.6.0"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+				"eslint": "^8.56.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.15.0.tgz",
-			"integrity": "sha512-h8vYOulWec9LhpwfAdZf2bjr8xIp0KNKnpgqSz0qqYYKAW/QZKw3ktRndbiAtUz4acH4QLQavwZBYCc0wulA/Q==",
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.8.0.tgz",
+			"integrity": "sha512-q4/gibTNBQNA0lGyYQCmWRS5D15n8rXh4QjK3KV+MBPlTYHpfBUT3D3PaPR/HeNiI9W6R7FvlkcGhNyAoP+caA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "8.15.0",
-				"eslint-visitor-keys": "^4.2.0"
+				"@typescript-eslint/types": "7.8.0",
+				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^18.18.0 || >=20.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
-			"dev": true,
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@ungap/structured-clone": {

--- a/frontend/user-dashboard/package.json
+++ b/frontend/user-dashboard/package.json
@@ -18,7 +18,7 @@
 		"@sveltejs/kit": "^2.8.1",
 		"@sveltejs/vite-plugin-svelte": "^4.0.1",
 		"@types/eslint": "^8.56.0",
-		"@typescript-eslint/eslint-plugin": "^8.15.0",
+		"@typescript-eslint/eslint-plugin": "^7.0.0",
 		"@typescript-eslint/parser": "^7.18.0",
 		"autoprefixer": "^10.4.20",
 		"eslint": "^8.56.0",


### PR DESCRIPTION
Reverts Knoblauchpilze/galactic-sovereign#142

This seems to cause some issues with conflicting dependencies version.

See also #128.