### PR TITLE
feat: Dummy change to allow opening a PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 
-# Provide tag as:
-# GIT_COMMIT_HASH=$(git rev-parse --short HEAD)
+GIT_COMMIT_HASH=$(shell git rev-parse --short HEAD)
 NODE_PORT ?= 3001
 SERVER_ORIGIN ?= "http://localhost:3001"
 USER_API_BASE_URL ?= "http://user-service:80/v1/users"


### PR DESCRIPTION
# Work

This PR is a convenience shortcut to allow easy access to the state of the monorepo before we align it with what is done in [user-service](https://github.com/Knoblauchpilze/user-service) and [ec2-deployment](https://github.com/Knoblauchpilze/ec2-deployment).

# Tests

# Future work
