### PR TITLE
chore: Bumped backend toolkit to v0.6.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,11 +36,11 @@ require (
 )
 
 require (
-	github.com/Knoblauchpilze/backend-toolkit v0.6.4
+	github.com/Knoblauchpilze/backend-toolkit v0.6.5
 	github.com/Knoblauchpilze/easy-assert v0.4.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
-	github.com/jackc/pgx/v5 v5.9.2 // indirect
+	github.com/jackc/pgx/v5 v5.10.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Knoblauchpilze/backend-toolkit v0.6.4 h1:r0oB4jNG1bUuwAnN1C53ynznGIr21jEve29fCifZPDQ=
 github.com/Knoblauchpilze/backend-toolkit v0.6.4/go.mod h1:T5Hck6ny6meRsIX2Jvct6vCMO35jlmVGHiqjyh+gZXc=
+github.com/Knoblauchpilze/backend-toolkit v0.6.5 h1:FtigHZM54rkwkJT+CtnZ3vlUwVIQzuenB3noQFOo644=
+github.com/Knoblauchpilze/backend-toolkit v0.6.5/go.mod h1:Ff2gYYKcaLv91d+ZEuPo+W7vyc9DTkU5kcABRJvuiaE=
 github.com/Knoblauchpilze/easy-assert v0.4.0 h1:+Eanp7k3nnaHPP3eLbif3qkTNx0rb/qq0lLCL0zO06E=
 github.com/Knoblauchpilze/easy-assert v0.4.0/go.mod h1:vFiqu9yxaa2pEFoz4eXp2tst7sn8U+CkT2dgppiEYTI=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
@@ -39,6 +41,8 @@ github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7Ulw
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
 github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.10.0 h1:VhSvgU2jSli8o3AqIEOTJr7rZwAEUVo4E4XhR94Zfr0=
+github.com/jackc/pgx/v5 v5.10.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=

--- a/internal/controller/building_action.go
+++ b/internal/controller/building_action.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/rest"
 	"github.com/Knoblauchpilze/galactic-sovereign/internal/service"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/communication"
@@ -61,10 +59,10 @@ func createBuildingAction(c *echo.Context, s service.BuildingActionService) erro
 
 	out, err := s.Create(c.Request().Context(), actionDtoRequest)
 	if err != nil {
-		if errors.IsErrorWithCode(err, game.NotEnoughResources) {
+		if err == game.ErrNotEnoughResources {
 			return c.JSON(http.StatusBadRequest, "Not enough resources")
 		}
-		if errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation) {
+		if dbErr, ok := db.AsDatabaseError(err); ok && dbErr.Code == db.ErrUniqueConstraintViolation {
 			return c.JSON(http.StatusConflict, "Building action already exists")
 		}
 
@@ -95,7 +93,7 @@ func deleteBuildingAction(c *echo.Context, s service.BuildingActionService) erro
 
 	err = s.Delete(c.Request().Context(), id)
 	if err != nil {
-		if errors.IsErrorWithCode(err, db.NoMatchingRows) {
+		if err == db.ErrNoMatchingRows {
 			return c.JSON(http.StatusNotFound, "No such action")
 		}
 

--- a/internal/controller/building_action_test.go
+++ b/internal/controller/building_action_test.go
@@ -11,8 +11,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/rest"
 	"github.com/Knoblauchpilze/galactic-sovereign/internal/service"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/communication"
@@ -168,14 +166,14 @@ func TestUnit_BuildingActionController(t *testing.T) {
 				req:                generateTestRequestWithBuildingActionBody(http.MethodPost, defaultBuildingActionDtoRequest),
 				idAsRouteParam:     true,
 				handler:            createBuildingAction,
-				err:                errors.NewCode(game.NotEnoughResources),
+				err:                game.ErrNotEnoughResources,
 				expectedHttpStatus: http.StatusBadRequest,
 			},
 			"createBuildingAction_buildingActionAlreadyInProgress": {
 				req:                generateTestRequestWithBuildingActionBody(http.MethodPost, defaultBuildingActionDtoRequest),
 				idAsRouteParam:     true,
 				handler:            createBuildingAction,
-				err:                errors.NewCode(pgx.UniqueConstraintViolation),
+				err:                &db.DatabaseError{Code: db.ErrUniqueConstraintViolation},
 				expectedHttpStatus: http.StatusConflict,
 			},
 			"deleteBuildingAction": {
@@ -189,7 +187,7 @@ func TestUnit_BuildingActionController(t *testing.T) {
 				req:                httptest.NewRequest(http.MethodDelete, "/", nil),
 				idAsRouteParam:     true,
 				handler:            deleteBuildingAction,
-				err:                errors.NewCode(db.NoMatchingRows),
+				err:                db.ErrNoMatchingRows,
 				expectedHttpStatus: http.StatusNotFound,
 			},
 		},

--- a/internal/service/action_service.go
+++ b/internal/service/action_service.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/game"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/repositories"
@@ -133,7 +132,7 @@ func (s *actionServiceImpl) updatePlanetProductionForResource(
 
 	production, err := s.planetResourceProductionRepo.GetForPlanetAndBuilding(ctx, tx, action.Planet, &action.Building)
 	if err != nil {
-		if errors.IsErrorWithCode(err, db.NoMatchingRows) {
+		if err == db.ErrNoMatchingRows {
 			return s.createPlanetProductionForResourceAndBuilding(ctx, tx, action, newProduction)
 		}
 
@@ -188,8 +187,8 @@ func (s *actionServiceImpl) updatePlanetStorageForResource(
 		newStorage.Resource,
 	)
 	if err != nil {
-		if errors.IsErrorWithCode(err, db.NoMatchingRows) {
-			return errors.WrapCode(err, ActionUpdatesUnknownResource)
+		if err == db.ErrNoMatchingRows {
+			return ErrActionUpdatesUnknownResource
 		}
 		return err
 	}

--- a/internal/service/action_service_test.go
+++ b/internal/service/action_service_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/game"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/repositories"
 	"github.com/google/uuid"
@@ -63,7 +62,7 @@ func TestIT_ActionService_ProcessActionUntil_WhenProcessingFail_ExpectActionIsNo
 
 	// Processing this action fails because the building associated with
 	// it does not exist on the planet.
-	assert.True(t, errors.IsErrorWithCode(err, db.NoMatchingRows))
+	assert.Equal(t, db.ErrNoMatchingRows, err)
 	assertBuildingActionExists(t, conn, action.Id)
 }
 
@@ -406,7 +405,7 @@ func TestIT_ActionService_ProcessActionUntil_WhenResourceIsNotStorable_ExpectFai
 	afterActionCompletes := completedAt.Add(1 * time.Second)
 	err := service.ProcessActionsUntil(context.Background(), planetId, afterActionCompletes)
 
-	assert.True(t, errors.IsErrorWithCode(err, ActionUpdatesUnknownResource))
+	assert.Equal(t, ErrActionUpdatesUnknownResource, err)
 }
 
 func newTestActionService(t *testing.T) (game.ActionService, db.Connection) {

--- a/internal/service/building_action_service.go
+++ b/internal/service/building_action_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/communication"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/game"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
@@ -124,7 +123,7 @@ func (s *buildingActionServiceImpl) Delete(ctx context.Context, id uuid.UUID) er
 	}
 
 	if action.CompletedAt.Before(tx.TimeStamp()) {
-		return errors.NewCode(ActionAlreadyCompleted)
+		return ErrActionAlreadyCompleted
 	}
 
 	costs, err := s.buildingActionCostRepo.ListForAction(ctx, tx, action.Id)

--- a/internal/service/building_action_service_test.go
+++ b/internal/service/building_action_service_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	eassert "github.com/Knoblauchpilze/easy-assert/assert"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/communication"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/game"
@@ -53,7 +52,7 @@ func TestIT_BuildingActionService_Create_WhenNotEnoughResources_ExpectFailure(t 
 	}
 	_, err := service.Create(context.Background(), actionRequest)
 
-	assert.True(t, errors.IsErrorWithCode(err, game.NotEnoughResources))
+	assert.Equal(t, game.ErrNotEnoughResources, err)
 }
 
 func TestIT_BuildingActionService_Create_WhenBuildingDoesNotExist_ExpectFailure(t *testing.T) {
@@ -69,7 +68,7 @@ func TestIT_BuildingActionService_Create_WhenBuildingDoesNotExist_ExpectFailure(
 	}
 	_, err := service.Create(context.Background(), actionRequest)
 
-	assert.True(t, errors.IsErrorWithCode(err, game.NoSuchBuilding))
+	assert.Equal(t, game.ErrNoSuchBuilding, err)
 }
 
 func TestIT_BuildingActionService_Create_WithCost_ExpectCostToBeRegistered(t *testing.T) {
@@ -260,7 +259,7 @@ func TestIT_BuildingActionService_Delete_WhenActionAlreadyCompleted_ExpectFailur
 
 	err := service.Delete(context.Background(), action.Id)
 
-	assert.True(t, errors.IsErrorWithCode(err, ActionAlreadyCompleted), "Actual err: %v", err)
+	assert.Equal(t, ErrActionAlreadyCompleted, err, "Actual err: %v", err)
 }
 
 func TestIT_BuildingActionService_CreationDeletionWorkflow(t *testing.T) {

--- a/internal/service/errors.go
+++ b/internal/service/errors.go
@@ -5,16 +5,30 @@ import (
 )
 
 const (
-	InvalidEmail    errors.ErrorCode = 230
-	InvalidPassword errors.ErrorCode = 231
+	errInvalidEmail    errors.ErrorCode = 230
+	errInvalidPassword errors.ErrorCode = 231
 
-	noSuchResource               errors.ErrorCode = 240
-	ActionUsesUnknownResource    errors.ErrorCode = 241
-	ConflictingStateForAction    errors.ErrorCode = 242
-	ActionAlreadyCompleted       errors.ErrorCode = 243
-	ActionUpdatesUnknownResource errors.ErrorCode = 244
+	errNoSuchResource               errors.ErrorCode = 240
+	errActionUsesUnknownResource    errors.ErrorCode = 241
+	errConflictingStateForAction    errors.ErrorCode = 242
+	errActionAlreadyCompleted       errors.ErrorCode = 243
+	errActionUpdatesUnknownResource errors.ErrorCode = 244
 
-	InvalidCredentials    errors.ErrorCode = 250
-	UserNotAuthenticated  errors.ErrorCode = 251
-	AuthenticationExpired errors.ErrorCode = 252
+	errInvalidCredentials    errors.ErrorCode = 250
+	errUserNotAuthenticated  errors.ErrorCode = 251
+	errAuthenticationExpired errors.ErrorCode = 252
+)
+
+var (
+	ErrInvalidEmail    = errors.FromCode(errInvalidEmail)
+	ErrInvalidPassword = errors.FromCode(errInvalidPassword)
+
+	ErrActionUsesUnknownResource    = errors.FromCode(errActionUsesUnknownResource)
+	ErrConflictingStateForAction    = errors.FromCode(errConflictingStateForAction)
+	ErrActionAlreadyCompleted       = errors.FromCode(errActionAlreadyCompleted)
+	ErrActionUpdatesUnknownResource = errors.FromCode(errActionUpdatesUnknownResource)
+
+	ErrInvalidCredentials    = errors.FromCode(errInvalidCredentials)
+	ErrUserNotAuthenticated  = errors.FromCode(errUserNotAuthenticated)
+	ErrAuthenticationExpired = errors.FromCode(errAuthenticationExpired)
 )

--- a/internal/service/resource_utils.go
+++ b/internal/service/resource_utils.go
@@ -25,15 +25,15 @@ func findResourceForCost(resources []persistence.PlanetResource, cost persistenc
 		}
 	}
 
-	return persistence.PlanetResource{}, errors.NewCode(noSuchResource)
+	return persistence.PlanetResource{}, errors.FromCode(errNoSuchResource)
 }
 
 func updatePlanetResourceWithCosts(ctx context.Context, tx db.Transaction, repo repositories.PlanetResourceRepository, resources []persistence.PlanetResource, costs []persistence.BuildingActionCost, update updateFunc) error {
 	for _, cost := range costs {
 		resource, err := findResourceForCost(resources, cost)
 		if err != nil {
-			if errors.IsErrorWithCode(err, noSuchResource) {
-				return errors.NewCode(ActionUsesUnknownResource)
+			if errCode, ok := errors.AsErrorWithCode(err); ok && errCode.Code == errNoSuchResource {
+				return ErrActionUsesUnknownResource
 			}
 
 			return err
@@ -44,8 +44,8 @@ func updatePlanetResourceWithCosts(ctx context.Context, tx db.Transaction, repo 
 
 		_, err = repo.Update(ctx, tx, planetResource)
 		if err != nil {
-			if errors.IsErrorWithCode(err, repositories.OptimisticLockException) {
-				return errors.NewCode(ConflictingStateForAction)
+			if err == repositories.ErrOptimisticLockException {
+				return ErrConflictingStateForAction
 			}
 
 			return err

--- a/internal/service/resource_utils_test.go
+++ b/internal/service/resource_utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/repositories"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var defaultResourceId = uuid.MustParse("f568a280-92ec-4752-b14b-5e71070cce3e")
@@ -28,8 +29,6 @@ var defaultActionCosts = []persistence.BuildingActionCost{
 }
 
 func TestUnit_FindResourceForCost_NoSuchResource(t *testing.T) {
-	assert := assert.New(t)
-
 	cost := persistence.BuildingActionCost{
 		Resource: otherResourceid,
 		Amount:   2,
@@ -37,7 +36,9 @@ func TestUnit_FindResourceForCost_NoSuchResource(t *testing.T) {
 
 	_, err := findResourceForCost(defaultPlanetResources, cost)
 
-	assert.True(errors.IsErrorWithCode(err, noSuchResource))
+	actual, ok := errors.AsErrorWithCode(err)
+	require.True(t, ok)
+	assert.Equal(t, errNoSuchResource, actual.Code)
 }
 
 func TestUnit_FindResourceForCost_ResourceExist(t *testing.T) {
@@ -56,8 +57,6 @@ func TestUnit_FindResourceForCost_ResourceExist(t *testing.T) {
 }
 
 func TestUnit_UpdatePlanetResourceWithCosts_ResourceNotFound(t *testing.T) {
-	assert := assert.New(t)
-
 	costs := []persistence.BuildingActionCost{
 		{
 			Resource: otherResourceid,
@@ -67,7 +66,7 @@ func TestUnit_UpdatePlanetResourceWithCosts_ResourceNotFound(t *testing.T) {
 
 	err := updatePlanetResourceWithCosts(context.Background(), nil, &mockPlanetResourceRepository{}, defaultPlanetResources, costs, addResource)
 
-	assert.True(errors.IsErrorWithCode(err, ActionUsesUnknownResource))
+	assert.Equal(t, ErrActionUsesUnknownResource, err)
 }
 
 func TestUnit_UpdatePlanetResourceWithCosts_UpdateResourceInDb(t *testing.T) {
@@ -123,14 +122,12 @@ func TestUnit_UpdatePlanetResourceWithCosts_Update_Fails(t *testing.T) {
 }
 
 func TestUnit_UpdatePlanetResourceWithCosts_Update_OptimisticLockException(t *testing.T) {
-	assert := assert.New(t)
-
 	m := &mockPlanetResourceRepository{
-		updateErr: errors.NewCode(repositories.OptimisticLockException),
+		updateErr: repositories.ErrOptimisticLockException,
 	}
 
 	err := updatePlanetResourceWithCosts(context.Background(), nil, m, defaultPlanetResources, defaultActionCosts, addResource)
 
-	assert.True(errors.IsErrorWithCode(err, ConflictingStateForAction))
-	assert.Equal(1, m.updateCalled)
+	assert.Equal(t, ErrConflictingStateForAction, err)
+	assert.Equal(t, 1, m.updateCalled)
 }

--- a/pkg/domain/adapters/driven/building_action_repository_test.go
+++ b/pkg/domain/adapters/driven/building_action_repository_test.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models"
 	domainerrors "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models/errors"
 	drivenports "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/ports/driven"
@@ -176,12 +174,9 @@ func TestIT_BuildingActionRepository_Create(t *testing.T) {
 
 		err := repo.Create(context.Background(), newAction)
 
-		assert.True(
-			t,
-			errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation),
-			"Actual err: %v",
-			err,
-		)
+		actual, ok := db.AsDatabaseError(err)
+		require.True(t, ok, "Actual err: %v", err)
+		assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 		assertBuildingActionDoesNotExist(t, conn, newAction.Id)
 	})
 }

--- a/pkg/domain/adapters/driven/database_checker_test.go
+++ b/pkg/domain/adapters/driven/database_checker_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -29,6 +28,6 @@ func TestIT_DatabaseChecker_Ping(t *testing.T) {
 
 		err := checker.Ping(context.Background())
 
-		assert.True(t, errors.IsErrorWithCode(err, db.NotConnected), "Actual err: %v", err)
+		assert.Equal(t, db.ErrNotConnected, err, "Actual err: %v", err)
 	})
 }

--- a/pkg/domain/adapters/driven/db_error_parser.go
+++ b/pkg/domain/adapters/driven/db_error_parser.go
@@ -2,7 +2,6 @@ package drivenadapters
 
 import (
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	domainerrors "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models/errors"
 )
 
@@ -11,7 +10,7 @@ func parseDbError(err error) error {
 		return nil
 	}
 
-	if errors.IsErrorWithCode(err, db.NoMatchingRows) {
+	if err == db.ErrNoMatchingRows {
 		return domainerrors.ErrNotFound
 	}
 

--- a/pkg/domain/adapters/driven/planet_repository_test.go
+++ b/pkg/domain/adapters/driven/planet_repository_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models"
 	domainerrors "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models/errors"
 	drivenports "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/ports/driven"
@@ -263,7 +261,9 @@ func TestIT_PlanetRepository_Create(t *testing.T) {
 		}
 
 		err := repo.Create(context.Background(), duplicatedPlanet)
-		assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+		actual, ok := db.AsDatabaseError(err)
+		require.True(t, ok)
+		assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	})
 
 	t.Run("creates homeworld and marks it as such", func(t *testing.T) {
@@ -307,7 +307,9 @@ func TestIT_PlanetRepository_Create(t *testing.T) {
 		}
 
 		err := repo.Create(context.Background(), planet)
-		assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+		actual, ok := db.AsDatabaseError(err)
+		require.True(t, ok)
+		assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 		assertPlanetDoesNotExist(t, conn, planet.Id)
 	})
 }

--- a/pkg/domain/adapters/driven/player_repository_test.go
+++ b/pkg/domain/adapters/driven/player_repository_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models"
 	domainerrors "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models/errors"
 	drivenports "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/ports/driven"
@@ -74,7 +72,9 @@ func TestIT_PlayerRepository_Create(t *testing.T) {
 
 		err := repo.Create(context.Background(), newPlayer)
 
-		assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+		actual, ok := db.AsDatabaseError(err)
+		require.True(t, ok)
+		assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 		assertPlayerDoesNotExist(t, conn, newPlayer.Id)
 	})
 }

--- a/pkg/domain/adapters/driven/universe_repository_test.go
+++ b/pkg/domain/adapters/driven/universe_repository_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models"
 	domainerrors "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models/errors"
 	drivenports "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/ports/driven"
@@ -48,7 +46,9 @@ func TestIT_UniverseRepository_Create(t *testing.T) {
 
 		err := repo.Create(context.Background(), newUniverse)
 
-		assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+		actual, ok := db.AsDatabaseError(err)
+		require.True(t, ok)
+		assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 		assertUniverseDoesNotExist(t, conn, newUniverse.Id)
 	})
 

--- a/pkg/domain/adapters/driving/planets.go
+++ b/pkg/domain/adapters/driving/planets.go
@@ -4,8 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
+	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/rest"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/adapters/driving/dtos"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/adapters/driving/mappers"
@@ -59,7 +58,7 @@ func createPlanet(c *echo.Context, usecase drivingports.ForManagingPlanet) error
 	request := mappers.ToPlanetCreationRequest(inputDto)
 	planet, err := usecase.Create(c.Request().Context(), request)
 	if err != nil {
-		if errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation) {
+		if dbErr, ok := db.AsDatabaseError(err); ok && dbErr.Code == db.ErrUniqueConstraintViolation {
 			return c.JSON(http.StatusConflict, "name already used")
 		}
 

--- a/pkg/domain/adapters/driving/players.go
+++ b/pkg/domain/adapters/driving/players.go
@@ -4,8 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
+	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/rest"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/adapters/driving/dtos"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/adapters/driving/mappers"
@@ -60,7 +59,7 @@ func createPlayer(c *echo.Context, usecase drivingports.ForManagingPlayer) error
 	request := mappers.ToPlayerCreationRequest(inputDto)
 	player, err := usecase.Create(c.Request().Context(), request)
 	if err != nil {
-		if errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation) {
+		if dbErr, ok := db.AsDatabaseError(err); ok && dbErr.Code == db.ErrUniqueConstraintViolation {
 			return c.JSON(http.StatusConflict, "name already used")
 		}
 

--- a/pkg/domain/adapters/driving/universes.go
+++ b/pkg/domain/adapters/driving/universes.go
@@ -4,8 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
+	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/rest"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/adapters/driving/dtos"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/adapters/driving/mappers"
@@ -59,7 +58,7 @@ func createUniverse(c *echo.Context, usecase drivingports.ForManagingUniverse) e
 	request := mappers.ToUniverseCreationRequest(inputDto)
 	universe, err := usecase.Create(c.Request().Context(), request)
 	if err != nil {
-		if errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation) {
+		if dbErr, ok := db.AsDatabaseError(err); ok && dbErr.Code == db.ErrUniqueConstraintViolation {
 			return c.JSON(http.StatusConflict, "name already used")
 		}
 

--- a/pkg/domain/app/models/errors.go
+++ b/pkg/domain/app/models/errors.go
@@ -5,5 +5,5 @@ import "github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 var (
 	noSuchBuilding errors.ErrorCode = 270
 
-	errBuildingNotFound = errors.NewCode(noSuchBuilding)
+	errBuildingNotFound = errors.FromCode(noSuchBuilding)
 )

--- a/pkg/domain/app/models/errors/errors.go
+++ b/pkg/domain/app/models/errors/errors.go
@@ -7,5 +7,5 @@ const (
 )
 
 var (
-	ErrNotFound = errors.NewCode(resourceNotFound)
+	ErrNotFound = errors.FromCode(resourceNotFound)
 )

--- a/pkg/domain/app/usecases/manage_building_action_test.go
+++ b/pkg/domain/app/usecases/manage_building_action_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models"
+	domainerrors "github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/models/request"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/domain/app/usecases/drivenportstest"
 	"github.com/google/uuid"
@@ -114,12 +114,12 @@ func TestUnit_ManageBuildingAction_Create(t *testing.T) {
 		mockPlanetRepo.EXPECT().
 			Get(gomock.Any(), gomock.Eq(request.Planet)).
 			Times(1).
-			Return(models.Planet{}, errors.NewCode(db.NoMatchingRows))
+			Return(models.Planet{}, domainerrors.ErrNotFound)
 
 		usecase := NewBuildingActionUseCase(mockActionRepo, mockPlanetRepo, mockBuildingRepo)
 		_, err := usecase.Create(context.Background(), request)
 
-		assert.True(t, errors.IsErrorWithCode(err, db.NoMatchingRows), "Actual err: %v", err)
+		assert.Equal(t, domainerrors.ErrNotFound, err, "Actual err: %v", err)
 	})
 
 	t.Run("returns error when building is not found", func(t *testing.T) {
@@ -131,12 +131,12 @@ func TestUnit_ManageBuildingAction_Create(t *testing.T) {
 		mockBuildingRepo.EXPECT().
 			Get(gomock.Any(), gomock.Eq(request.Building)).
 			Times(1).
-			Return(models.Building{}, errors.NewCode(db.NoMatchingRows))
+			Return(models.Building{}, domainerrors.ErrNotFound)
 
 		usecase := NewBuildingActionUseCase(mockActionRepo, mockPlanetRepo, mockBuildingRepo)
 		_, err := usecase.Create(context.Background(), request)
 
-		assert.True(t, errors.IsErrorWithCode(err, db.NoMatchingRows), "Actual err: %v", err)
+		assert.Equal(t, domainerrors.ErrNotFound, err, "Actual err: %v", err)
 	})
 
 	t.Run("returns error when repository fails", func(t *testing.T) {

--- a/pkg/game/action.go
+++ b/pkg/game/action.go
@@ -3,7 +3,6 @@ package game
 import (
 	"math"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
 )
@@ -128,7 +127,7 @@ func validateActionBuilding(
 		}
 	}
 
-	return errors.NewCode(NoSuchBuilding)
+	return ErrNoSuchBuilding
 }
 
 func validateActionCost(
@@ -143,7 +142,7 @@ func validateActionCost(
 	for _, cost := range costs {
 		actual, ok := temp[cost.Resource]
 		if !ok || actual.Amount < float64(cost.Amount) {
-			return errors.NewCode(NotEnoughResources)
+			return ErrNotEnoughResources
 		}
 	}
 

--- a/pkg/game/action_test.go
+++ b/pkg/game/action_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -165,8 +164,6 @@ func TestUnit_ConsolidateBuildingActionLevel_WhenBuildingExists_SetsCorrectLevel
 }
 
 func TestUnit_ConsolidateBuildingActionCompletionTime_WhenResourceNotFound_ExpectError(t *testing.T) {
-	assert := assert.New(t)
-
 	action := persistence.BuildingAction{
 		Building: defaultId,
 	}
@@ -189,7 +186,7 @@ func TestUnit_ConsolidateBuildingActionCompletionTime_WhenResourceNotFound_Expec
 
 	_, err := ConsolidateBuildingActionCompletionTime(action, resources, costs)
 
-	assert.True(errors.IsErrorWithCode(err, NoSuchResource))
+	assert.Equal(t, ErrNoSuchResource, err, "Actual err: %v")
 }
 
 func TestUnit_ConsolidateBuildingActionCompletionTime(t *testing.T) {
@@ -217,8 +214,6 @@ func TestUnit_ConsolidateBuildingActionCompletionTime(t *testing.T) {
 }
 
 func TestUnit_ValidateActionBuilding_NoSuchBuilding(t *testing.T) {
-	assert := assert.New(t)
-
 	action := persistence.BuildingAction{
 		Building: defaultId,
 	}
@@ -226,7 +221,7 @@ func TestUnit_ValidateActionBuilding_NoSuchBuilding(t *testing.T) {
 
 	err := validateActionBuilding(action, buildings)
 
-	assert.True(errors.IsErrorWithCode(err, NoSuchBuilding))
+	assert.Equal(t, ErrNoSuchBuilding, err, "Actual err: %v")
 }
 
 func TestUnit_ValidateActionBuilding(t *testing.T) {
@@ -247,8 +242,6 @@ func TestUnit_ValidateActionBuilding(t *testing.T) {
 }
 
 func TestUnit_ValidateActionCost_NoSuchResource(t *testing.T) {
-	assert := assert.New(t)
-
 	resources := []persistence.PlanetResource{}
 	costs := []persistence.BuildingActionCost{
 		{
@@ -259,12 +252,10 @@ func TestUnit_ValidateActionCost_NoSuchResource(t *testing.T) {
 
 	err := validateActionCost(resources, costs)
 
-	assert.True(errors.IsErrorWithCode(err, NotEnoughResources))
+	assert.Equal(t, ErrNotEnoughResources, err, "Actual err: %v")
 }
 
 func TestUnit_ValidateActionCost_TooLittleResource(t *testing.T) {
-	assert := assert.New(t)
-
 	resources := []persistence.PlanetResource{
 		{
 			Resource: defaultId,
@@ -280,7 +271,7 @@ func TestUnit_ValidateActionCost_TooLittleResource(t *testing.T) {
 
 	err := validateActionCost(resources, costs)
 
-	assert.True(errors.IsErrorWithCode(err, NotEnoughResources))
+	assert.Equal(t, ErrNotEnoughResources, err, "Actual err: %v")
 }
 
 func TestUnit_ValidateActionCost_ExactlyEnoughResource(t *testing.T) {
@@ -326,8 +317,6 @@ func TestUnit_ValidateActionCost_MoreThanEnoughResource(t *testing.T) {
 }
 
 func TestUnit_ValidateBuildingAction_BuildingUnknown(t *testing.T) {
-	assert := assert.New(t)
-
 	action := persistence.BuildingAction{
 		Building: defaultId,
 	}
@@ -347,12 +336,10 @@ func TestUnit_ValidateBuildingAction_BuildingUnknown(t *testing.T) {
 
 	err := ValidateBuildingAction(action, resources, buildings, costs)
 
-	assert.True(errors.IsErrorWithCode(err, NoSuchBuilding))
+	assert.Equal(t, ErrNoSuchBuilding, err, "Actual err: %v")
 }
 
 func TestUnit_ValidateBuildingAction_CostFails(t *testing.T) {
-	assert := assert.New(t)
-
 	action := persistence.BuildingAction{
 		Building: defaultId,
 	}
@@ -376,7 +363,7 @@ func TestUnit_ValidateBuildingAction_CostFails(t *testing.T) {
 
 	err := ValidateBuildingAction(action, resources, buildings, costs)
 
-	assert.True(errors.IsErrorWithCode(err, NotEnoughResources))
+	assert.Equal(t, ErrNotEnoughResources, err, "Actual err: %v")
 }
 
 func TestUnit_ValidateBuildingAction(t *testing.T) {

--- a/pkg/game/completion_time.go
+++ b/pkg/game/completion_time.go
@@ -4,7 +4,6 @@ import (
 	"math"
 	"time"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 )
 
@@ -23,7 +22,7 @@ func findResourceByName(name string, resources []persistence.Resource) *persiste
 func findResourceRequirementByName(name string, resources []persistence.Resource, costs []persistence.BuildingActionCost) (float64, error) {
 	resource := findResourceByName(name, resources)
 	if resource == nil {
-		return 0.0, errors.NewCode(NoSuchResource)
+		return 0.0, ErrNoSuchResource
 	}
 
 	for _, cost := range costs {

--- a/pkg/game/completion_time_test.go
+++ b/pkg/game/completion_time_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -25,19 +24,15 @@ var defaultResources = []persistence.Resource{
 }
 
 func TestUnit_BuildingCompletionTimeFromCost_whenMetalNotFound_expectError(t *testing.T) {
-	assert := assert.New(t)
-
 	resources := []persistence.Resource{}
 	costs := []persistence.BuildingActionCost{}
 
 	_, err := buildingCompletionTimeFromCost(resources, costs)
 
-	assert.True(errors.IsErrorWithCode(err, NoSuchResource))
+	assert.Equal(t, ErrNoSuchResource, err, "Actual err: %v", err)
 }
 
 func TestUnit_BuildingCompletionTimeFromCost_whenCrystalNotFound_expectError(t *testing.T) {
-	assert := assert.New(t)
-
 	resources := []persistence.Resource{
 		{
 			Id:   defaultMetalId,
@@ -48,7 +43,7 @@ func TestUnit_BuildingCompletionTimeFromCost_whenCrystalNotFound_expectError(t *
 
 	_, err := buildingCompletionTimeFromCost(resources, costs)
 
-	assert.True(errors.IsErrorWithCode(err, NoSuchResource))
+	assert.Equal(t, ErrNoSuchResource, err, "Actual err: %v", err)
 }
 
 func TestUnit_BuildingCompletionTimeFromCost_onlyMetalCost(t *testing.T) {

--- a/pkg/game/errors.go
+++ b/pkg/game/errors.go
@@ -3,11 +3,21 @@ package game
 import "github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 
 const (
-	NoSuchBuilding     errors.ErrorCode = 270
-	NotEnoughResources errors.ErrorCode = 271
+	errNoSuchBuilding     errors.ErrorCode = 270
+	errNotEnoughResources errors.ErrorCode = 271
 
-	NoSuchResource errors.ErrorCode = 280
+	errNoSuchResource errors.ErrorCode = 280
 
-	actionSchedulingFailed     errors.ErrorCode = 350
-	planetResourceUpdateFailed errors.ErrorCode = 351
+	errActionSchedulingFailed     errors.ErrorCode = 350
+	errPlanetResourceUpdateFailed errors.ErrorCode = 351
+)
+
+var (
+	ErrNoSuchBuilding     = errors.FromCode(errNoSuchBuilding)
+	ErrNotEnoughResources = errors.FromCode(errNotEnoughResources)
+
+	ErrNoSuchResource = errors.FromCode(errNoSuchResource)
+
+	// ErrActionSchedulingFailed     errors.ErrorCode = 350
+	// ErrPlanetResourceUpdateFailed errors.ErrorCode = 351
 )

--- a/pkg/game/game_update_watcher.go
+++ b/pkg/game/game_update_watcher.go
@@ -49,11 +49,11 @@ func GameUpdateWatcher(actionService ActionService, planetResourceService Planet
 }
 
 func handleError(err error, c *echo.Context) error {
-	if errors.IsErrorWithCode(err, actionSchedulingFailed) {
+	if errCode, ok := errors.AsErrorWithCode(err); ok && errCode.Code == errActionSchedulingFailed {
 		c.Logger().Error("Failed to scheduled pending actions", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, "Failed to process actions")
 	}
-	if errors.IsErrorWithCode(err, planetResourceUpdateFailed) {
+	if errCode, ok := errors.AsErrorWithCode(err); ok && errCode.Code == errPlanetResourceUpdateFailed {
 		c.Logger().Error("Failed to update planet resources", slog.Any("error", err))
 		return c.JSON(http.StatusInternalServerError, "Failed to update resources")
 	}
@@ -68,12 +68,12 @@ func (data *actionProcessingData) updateGameToCurrentTime(ctx context.Context, p
 
 	err := data.actionService.ProcessActionsUntil(ctx, planet, timeStamp)
 	if err != nil {
-		return errors.WrapCode(err, actionSchedulingFailed)
+		return errors.WrapCode(err, errActionSchedulingFailed)
 	}
 
 	err = data.planetResourceService.UpdatePlanetUntil(ctx, planet, timeStamp)
 	if err != nil {
-		return errors.WrapCode(err, planetResourceUpdateFailed)
+		return errors.WrapCode(err, errPlanetResourceUpdateFailed)
 	}
 
 	return nil

--- a/pkg/repositories/building_action_cost_repository_test.go
+++ b/pkg/repositories/building_action_cost_repository_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	eassert "github.com/Knoblauchpilze/easy-assert/assert"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
@@ -49,7 +47,9 @@ func TestIT_BuildingActionCostRepository_Create_WhenDuplicatedResource_ExpectFai
 	_, err := repo.Create(context.Background(), tx, newCost)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := db.AsDatabaseError(err)
+	require.True(t, ok)
+	assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	assertBuildingActionCostForResource(t, conn, action.Id, resource.Id, cost.Amount)
 }
 

--- a/pkg/repositories/building_action_repository_test.go
+++ b/pkg/repositories/building_action_repository_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	eassert "github.com/Knoblauchpilze/easy-assert/assert"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
@@ -58,7 +56,9 @@ func TestIT_BuildingActionRepository_Create_WhenDuplicatePlanet_ExpectFailure(t 
 
 	_, err := repo.Create(context.Background(), tx, newAction)
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := db.AsDatabaseError(err)
+	require.True(t, ok)
+	assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	assertBuildingActionDoesNotExist(t, conn, newAction.Id)
 }
 
@@ -82,7 +82,7 @@ func TestIT_BuildingActionRepository_Get_WhenNotFound_ExpectFailure(t *testing.T
 	// Non-existent id
 	id := uuid.MustParse("00000000-1111-2222-1111-000000000000")
 	_, err := repo.Get(context.Background(), tx, id)
-	assert.True(t, errors.IsErrorWithCode(err, db.NoMatchingRows), "Actual err: %v", err)
+	assert.Equal(t, db.ErrNoMatchingRows, err, "Actual err: %v", err)
 }
 
 func TestIT_BuildingActionRepository_ListForPlanet(t *testing.T) {

--- a/pkg/repositories/building_action_resource_production_repository_test.go
+++ b/pkg/repositories/building_action_resource_production_repository_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	eassert "github.com/Knoblauchpilze/easy-assert/assert"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
@@ -49,7 +47,9 @@ func TestIT_BuildingActionResourceProductionRepository_Create_WhenDuplicatedReso
 	_, err := repo.Create(context.Background(), tx, newProduction)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := db.AsDatabaseError(err)
+	require.True(t, ok)
+	assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	assertBuildingActionResourceProductionForResource(t, conn, action.Id, resource.Id, production.Production)
 }
 

--- a/pkg/repositories/building_action_resource_storage_repository_test.go
+++ b/pkg/repositories/building_action_resource_storage_repository_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	eassert "github.com/Knoblauchpilze/easy-assert/assert"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
@@ -49,7 +47,9 @@ func TestIT_BuildingActionResourceStorageRepository_Create_WhenDuplicatedResourc
 	_, err := repo.Create(context.Background(), tx, newStorage)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := db.AsDatabaseError(err)
+	require.True(t, ok)
+	assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	assertBuildingActionResourceStorageForResource(t, conn, action.Id, resource.Id, storage.Storage)
 }
 

--- a/pkg/repositories/errors.go
+++ b/pkg/repositories/errors.go
@@ -3,5 +3,9 @@ package repositories
 import "github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 
 const (
-	OptimisticLockException errors.ErrorCode = 200
+	errOptimisticLockException errors.ErrorCode = 200
+)
+
+var (
+	ErrOptimisticLockException = errors.FromCode(errOptimisticLockException)
 )

--- a/pkg/repositories/planet_building_repository.go
+++ b/pkg/repositories/planet_building_repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
 )
@@ -84,7 +83,7 @@ func (r *planetBuildingRepositoryImpl) Update(ctx context.Context, tx db.Transac
 		return building, err
 	}
 	if affectedRows != 1 {
-		return building, errors.NewCode(OptimisticLockException)
+		return building, ErrOptimisticLockException
 	}
 
 	building.Version = version

--- a/pkg/repositories/planet_building_repository_test.go
+++ b/pkg/repositories/planet_building_repository_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	eassert "github.com/Knoblauchpilze/easy-assert/assert"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
@@ -89,7 +88,7 @@ func TestIT_PlanetBuildingRepository_Update_WhenVersionIsWrong_ExpectOptimisticL
 	_, err := repo.Update(context.Background(), tx, updatedBuilding)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, OptimisticLockException), "Actual err: %v", err)
+	assert.Equal(t, ErrOptimisticLockException, err, "Actual err: %v", err)
 }
 
 func TestIT_PlanetBuildingRepository_Update_BumpsUpdatedAt(t *testing.T) {

--- a/pkg/repositories/planet_resource_production_repository.go
+++ b/pkg/repositories/planet_resource_production_repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
 )
@@ -167,7 +166,7 @@ func (r *planetResourceProductionRepositoryImpl) Update(
 		return production, err
 	}
 	if affectedRows != 1 {
-		return production, errors.NewCode(OptimisticLockException)
+		return production, ErrOptimisticLockException
 	}
 
 	production.Version = version

--- a/pkg/repositories/planet_resource_production_repository_test.go
+++ b/pkg/repositories/planet_resource_production_repository_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	eassert "github.com/Knoblauchpilze/easy-assert/assert"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
@@ -79,7 +77,9 @@ func TestIT_PlanetResourceProductionRepository_Create_WhenDuplicateResourceProdu
 	_, err := repo.Create(context.Background(), tx, newProd)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := db.AsDatabaseError(err)
+	require.True(t, ok)
+	assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	assertPlanetResourceProductionWithoutBuilding(t, conn, planetId, resource.Id, production.Production)
 }
 
@@ -100,7 +100,9 @@ func TestIT_PlanetResourceProductionRepository_Create_WhenDuplicateResourceProdu
 	_, err := repo.Create(context.Background(), tx, newProd)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := db.AsDatabaseError(err)
+	require.True(t, ok)
+	assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	assertPlanetResourceProductionForBuilding(t, conn, planetId, resource.Id, building.Id, production.Production)
 }
 
@@ -207,7 +209,7 @@ func TestIT_PlanetResourceProductionRepository_Update_WhenVersionIsWrong_ExpectO
 	_, err := repo.Update(context.Background(), tx, updatedProduction)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, OptimisticLockException), "Actual err: %v", err)
+	assert.Equal(t, ErrOptimisticLockException, err, "Actual err: %v", err)
 }
 
 func TestIT_PlanetResourceProductionRepository_Update_WithoutBuilding(t *testing.T) {
@@ -251,7 +253,7 @@ func TestIT_PlanetResourceProductionRepository_Update_WithoutBuilding_WhenVersio
 	_, err := repo.Update(context.Background(), tx, updatedProduction)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, OptimisticLockException), "Actual err: %v", err)
+	assert.Equal(t, ErrOptimisticLockException, err, "Actual err: %v", err)
 }
 
 func TestIT_PlanetResourceProductionRepository_Update_BumpsUpdatedAt(t *testing.T) {

--- a/pkg/repositories/planet_resource_repository.go
+++ b/pkg/repositories/planet_resource_repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
 )
@@ -69,7 +68,7 @@ func (r *planetResourceRepositoryImpl) Update(ctx context.Context, tx db.Transac
 		return resource, err
 	}
 	if affectedRows != 1 {
-		return resource, errors.NewCode(OptimisticLockException)
+		return resource, ErrOptimisticLockException
 	}
 
 	resource.Version = version

--- a/pkg/repositories/planet_resource_repository_test.go
+++ b/pkg/repositories/planet_resource_repository_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	eassert "github.com/Knoblauchpilze/easy-assert/assert"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
@@ -53,7 +51,9 @@ func TestIT_PlanetResourceRepository_Create_WhenDuplicateResource_ExpectFailure(
 	_, err := repo.Create(context.Background(), tx, newResource)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := db.AsDatabaseError(err)
+	require.True(t, ok)
+	assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	assertPlanetResourceAmount(t, conn, planetId, resource.Id, planetResource.Amount)
 }
 
@@ -118,7 +118,7 @@ func TestIT_PlanetResourceRepository_Update_WhenVersionIsWrong_ExpectOptimisticL
 	_, err := repo.Update(context.Background(), tx, updatedPlanetResource)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, OptimisticLockException), "Actual err: %v", err)
+	assert.Equal(t, ErrOptimisticLockException, err, "Actual err: %v", err)
 }
 
 func TestIT_PlanetResourceRepository_Update_BumpsUpdatedAt(t *testing.T) {

--- a/pkg/repositories/planet_resource_storage_repository.go
+++ b/pkg/repositories/planet_resource_storage_repository.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
 )
@@ -119,7 +118,7 @@ func (r *planetResourceStorageRepositoryImpl) Update(
 		return storage, err
 	}
 	if affectedRows != 1 {
-		return storage, errors.NewCode(OptimisticLockException)
+		return storage, ErrOptimisticLockException
 	}
 
 	storage.Version = version

--- a/pkg/repositories/planet_resource_storage_repository_test.go
+++ b/pkg/repositories/planet_resource_storage_repository_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	"github.com/Knoblauchpilze/backend-toolkit/pkg/db"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/db/pgx"
-	"github.com/Knoblauchpilze/backend-toolkit/pkg/errors"
 	eassert "github.com/Knoblauchpilze/easy-assert/assert"
 	"github.com/Knoblauchpilze/galactic-sovereign/pkg/persistence"
 	"github.com/google/uuid"
@@ -53,7 +51,9 @@ func TestIT_PlanetResourceStorageRepository_Create_WhenDuplicateResource_ExpectF
 	_, err := repo.Create(context.Background(), tx, newStorage)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, pgx.UniqueConstraintViolation), "Actual err: %v", err)
+	actual, ok := db.AsDatabaseError(err)
+	require.True(t, ok)
+	assert.Equal(t, db.ErrUniqueConstraintViolation, actual.Code, "Actual err: %v", err)
 	assertPlanetResourceStorage(t, conn, planetId, resource.Id, storage.Storage)
 }
 
@@ -140,7 +140,7 @@ func TestIT_PlanetResourceStorageRepository_Update_WhenVersionIsWrong_ExpectOpti
 	_, err := repo.Update(context.Background(), tx, updatedStorage)
 	tx.Close(context.Background())
 
-	assert.True(t, errors.IsErrorWithCode(err, OptimisticLockException), "Actual err: %v", err)
+	assert.Equal(t, ErrOptimisticLockException, err, "Actual err: %v", err)
 }
 
 func TestIT_PlanetResourceStorageRepository_Update_BumpsUpdatedAt(t *testing.T) {


### PR DESCRIPTION
# Work

Version 0.6.5 of the `backend-toolkit` library brings a revamp of error handling by:
* defining sentinel errors
* exposing the `ErrorWithCode` struct instead of relying on a `ErrorWithCode` interface
* introducing a `DatabaseError` with details about what went wrong in the SQL query

To leverage this in the project and be able to produce rich domain errors it is first needed to update the package.

This PR takes care of:
* bumping the version of the library
* adapting the tests logic to use the existing sentinel errors
* keep the existing logic as close as possible from the old approach with hidden error implementation

# Tests

The unit and integration tests were updated to correctly assert the equality of returned errors with sentinel errors and not rely on the error code so much.

The legacy code (i.e. `repositories` package, `services` and `controllers`) was minimally changed to match the new approach.

# Future work

With this update done, the domain can start using rich contextualized errors. This will be especially useful to allow:
* the driven adapters to emit domain errors
* the driving adapters to map domain errors to HTTP codes
